### PR TITLE
HHVM is not allowed to fail anymore. Inflector should work as expected.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,3 @@ php:
 
 before_script:
     - composer --prefer-source --dev install
-
-matrix:
-  allow_failures:
-    php: hhvm


### PR DESCRIPTION
HHVM is not allowed to fail anymore.
