### PR TITLE
Add a method to uppercase words with a custom delimeter.

### DIFF
--- a/lib/Doctrine/Common/Inflector/Inflector.php
+++ b/lib/Doctrine/Common/Inflector/Inflector.php
@@ -236,6 +236,42 @@ class Inflector
     }
 
     /**
+     * Uppercases words with configurable delimeters between words.
+     *
+     * Takes a string and capitalizes all of the words, like PHP's built-in
+     * ucwords function.  This extends that behavior, however, by allowing the
+     * word delimeters to be configured, rather than only separating on
+     * whitespace.
+     *
+     * Here is an example:
+     * <code>
+     * <?php
+     * $string = 'top-o-the-morning to all_of_you!';
+     * echo \Doctrine\Common\Inflector\Inflector::ucwords($string);
+     * // Top-O-The-Morning To All_of_you!
+     *
+     * echo \Doctrine\Common\Inflector\Inflector::ucwords($string, '-_ ');
+     * // Top-O-The-Morning To All_Of_You!
+     * ?>
+     * </code>
+     *
+     * @param string $string The string to operate on.
+     * @param string $delimiters A list of word separators.
+     *
+     * @return string The string with all delimeter-separated words capitalized.
+     */
+    public static function ucwords($string, $delimiters = " \n\t\r\0\x0B-")
+    {
+        return preg_replace_callback(
+            '/[^' . preg_quote($delimiters, '/') . ']+/',
+            function($matches) {
+                return ucfirst($matches[0]);
+            },
+            $string
+        );
+    }
+
+    /**
      * Clears Inflectors inflected value caches, and resets the inflection
      * rules to the initial values.
      *

--- a/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
+++ b/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
@@ -206,5 +206,25 @@ class InflectorTest extends DoctrineTestCase
         $this->assertEquals(Inflector::singularize('Alcoois'), 'Alcool');
         $this->assertEquals(Inflector::singularize('Atlas'), 'Atlas');
     }
+
+    /**
+     * Test basic ucwords functionality.
+     *
+     * @return void
+     */
+    public function testUcwords()
+    {
+        $this->assertSame('Top-O-The-Morning To All_of_you!', Inflector::ucwords( 'top-o-the-morning to all_of_you!'));
+    }
+
+    /**
+     * Test ucwords functionality with custom delimeters.
+     *
+     * @return void
+     */
+    public function testUcwordsWithCustomDelimeters()
+    {
+        $this->assertSame('Top-O-The-Morning To All_Of_You!', Inflector::ucwords( 'top-o-the-morning to all_of_you!', '-_ '));
+    }
 }
 


### PR DESCRIPTION
PHP's builtin ucwords() is generally useful, but there are oftem times
where whitespace isn't the only word separator you want to use to
capitalize on.  This ucwords() method makes it easy to handle arbitrary
single-character delimeters like hyphen (included by default), but also
any other configurable characters.