### PR TITLE
Criteria is plural, not singular

### DIFF
--- a/lib/Doctrine/Common/Inflector/Inflector.php
+++ b/lib/Doctrine/Common/Inflector/Inflector.php
@@ -77,7 +77,7 @@ class Inflector
             'cookie' => 'cookies',
             'corpus' => 'corpuses',
             'cow' => 'cows',
-            'criteria' => 'criterion',
+            'criterion' => 'criteria',
             'ganglion' => 'ganglions',
             'genie' => 'genies',
             'genus' => 'genera',

--- a/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
+++ b/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
@@ -59,7 +59,7 @@ class InflectorTest extends DoctrineTestCase
             array('foe', 'foes'),
             array('cookie', 'cookies'),
             array('identity', 'identities'),
-            array('criteria', 'criterion'),
+            array('criterion', 'criteria'),
             array('curve', 'curves'),
             array('', ''),
         );


### PR DESCRIPTION
Excuse if I'm wrong about this (English is not my native language), but isn't criteria plural? And criterion singular. See http://www.merriam-webster.com/dictionary/criterion for example.