### PR TITLE
the word 'us' should be not be inflected

### DIFF
--- a/lib/Doctrine/Common/Inflector/Inflector.php
+++ b/lib/Doctrine/Common/Inflector/Inflector.php
@@ -213,7 +213,7 @@ class Inflector
         'Pekingese', 'Piedmontese', 'pincers', 'Pistoiese', 'pliers', 'Portuguese',
         'proceedings', 'rabies', 'rice', 'rhinoceros', 'salmon', 'Sarawakese', 'scissors',
         'sea[- ]bass', 'series', 'Shavese', 'shears', 'siemens', 'species', 'staff', 'swine',
-        'testes', 'trousers', 'trout', 'tuna', 'Vermontese', 'Wenchowese', 'whiting',
+        'testes', 'trousers', 'trout', 'tuna', 'us', 'Vermontese', 'Wenchowese', 'whiting',
         'wildebeest', 'Yengeese'
     );
 


### PR DESCRIPTION
'us' should not be inflected. currently, it is being inflected to 'u' for singular, and 'uses' for plural
