### PR TITLE
Use delimiter argument within `ucwords()` if available

### DIFF
--- a/lib/Doctrine/Common/Inflector/Inflector.php
+++ b/lib/Doctrine/Common/Inflector/Inflector.php
@@ -252,7 +252,11 @@ class Inflector
      */
     public static function classify($word)
     {
-        return str_replace(" ", "", ucwords(strtr($word, "_-", "  ")));
+        if ((!defined('HHVM_VERSION_ID') || HHVM_VERSION_ID >= 31200) && (PHP_VERSION_ID >= 50516 || (PHP_VERSION_ID < 50500 && PHP_VERSION_ID >= 50432))) {
+            return str_replace(array(' ', '_', '-'), '', ucwords($word, ' _-'));
+        }
+
+        return str_replace(' ', '', ucwords(strtr($word, '_-', '  ')));
     }
 
     /**
@@ -271,7 +275,7 @@ class Inflector
      * Uppercases words with configurable delimeters between words.
      *
      * Takes a string and capitalizes all of the words, like PHP's built-in
-     * ucwords function.  This extends that behavior, however, by allowing the
+     * ucwords function. This extends that behavior, however, by allowing the
      * word delimeters to be configured, rather than only separating on
      * whitespace.
      *
@@ -294,6 +298,10 @@ class Inflector
      */
     public static function ucwords($string, $delimiters = " \n\t\r\0\x0B-")
     {
+        if ((!defined('HHVM_VERSION_ID') || HHVM_VERSION_ID >= 31200) && (PHP_VERSION_ID >= 50516 || (PHP_VERSION_ID < 50500 && PHP_VERSION_ID >= 50432))) {
+            return ucwords($string, $delimiters);
+        }
+
         return preg_replace_callback(
             '/[^' . preg_quote($delimiters, '/') . ']+/',
             function($matches) {
@@ -318,7 +326,7 @@ class Inflector
         }
 
         foreach (self::$initialState as $key => $val) {
-            if ($key != 'initialState') {
+            if ('initialState' !== $key) {
                 self::${$key} = $val;
             }
         }
@@ -355,7 +363,7 @@ class Inflector
             if ($reset) {
                 self::${$type}[$rule] = $pattern;
             } else {
-                self::${$type}[$rule] = ($rule === 'uninflected')
+                self::${$type}[$rule] = ('uninflected' === $rule)
                     ? array_merge($pattern, self::${$type}[$rule])
                     : $pattern + self::${$type}[$rule];
             }
@@ -366,9 +374,9 @@ class Inflector
                 unset(self::${$type}['merged'][$rule]);
             }
 
-            if ($type === 'plural') {
+            if ('plural' === $type) {
                 self::$cache['pluralize'] = self::$cache['tableize'] = array();
-            } elseif ($type === 'singular') {
+            } elseif ('singular' === $type) {
                 self::$cache['singularize'] = array();
             }
         }
@@ -404,7 +412,7 @@ class Inflector
 
         if (preg_match('/(.*)\\b(' . self::$plural['cacheIrregular'] . ')$/i', $word, $regs)) {
             self::$cache['pluralize'][$word] = $regs[1] . substr($word, 0, 1) . substr(self::$plural['merged']['irregular'][strtolower($regs[2])], 1);
-            
+
             return self::$cache['pluralize'][$word];
         }
 
@@ -457,7 +465,7 @@ class Inflector
 
         if (preg_match('/(.*)\\b(' . self::$singular['cacheIrregular'] . ')$/i', $word, $regs)) {
             self::$cache['singularize'][$word] = $regs[1] . substr($word, 0, 1) . substr(self::$singular['merged']['irregular'][strtolower($regs[2])], 1);
-            
+
             return self::$cache['singularize'][$word];
         }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Branch | master |
| Bug fix? | no |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #29 |
| License | MIT |
| Doc PR | n/a |

Closes #29.
