### PR TITLE
Add pluralization of 'niveau' => 'niveaux'

### DIFF
--- a/lib/Doctrine/Common/Inflector/Inflector.php
+++ b/lib/Doctrine/Common/Inflector/Inflector.php
@@ -76,6 +76,7 @@ class Inflector
             'brother' => 'brothers',
             'cafe' => 'cafes',
             'chateau' => 'chateaux',
+            'niveau' => 'niveaux',
             'child' => 'children',
             'cookie' => 'cookies',
             'corpus' => 'corpuses',

--- a/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
+++ b/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
@@ -37,6 +37,7 @@ class InflectorTest extends TestCase
             array('calf', 'calves'),
             array('categoria', 'categorias'),
             array('chateau', 'chateaux'),
+            array('niveau', 'niveaux'),
             array('cherry', 'cherries'),
             array('child', 'children'),
             array('church', 'churches'),


### PR DESCRIPTION
Plural 'niveau' is 'niveaux' (same as 'chateau' => 'chateaux')