### PR TITLE
singular of 'avalanches' is 'avalanche', not 'avalanch'

### DIFF
--- a/lib/Doctrine/Common/Inflector/Inflector.php
+++ b/lib/Doctrine/Common/Inflector/Inflector.php
@@ -201,16 +201,17 @@ class Inflector
             'clothes',
         ),
         'irregular' => array(
-            'caches'    => 'cache',
-            'criteria'  => 'criterion',
-            'curves'    => 'curve',
-            'emphases'  => 'emphasis',
-            'foes'      => 'foe',
-            'hoaxes'    => 'hoax',
-            'media'     => 'medium',
-            'neuroses'  => 'neurosis',
-            'waves'     => 'wave',
-            'oases'     => 'oasis',
+            'caches'     => 'cache',
+            'criteria'   => 'criterion',
+            'curves'     => 'curve',
+            'emphases'   => 'emphasis',
+            'foes'       => 'foe',
+            'hoaxes'     => 'hoax',
+            'media'      => 'medium',
+            'neuroses'   => 'neurosis',
+            'waves'      => 'wave',
+            'oases'      => 'oasis',
+            'avalanches' => 'avalanche'
         )
     );
 

--- a/lib/Doctrine/Common/Inflector/Inflector.php
+++ b/lib/Doctrine/Common/Inflector/Inflector.php
@@ -201,6 +201,7 @@ class Inflector
             'clothes',
         ),
         'irregular' => array(
+            'avalanches' => 'avalanche',
             'caches'     => 'cache',
             'criteria'   => 'criterion',
             'curves'     => 'curve',
@@ -211,7 +212,6 @@ class Inflector
             'neuroses'   => 'neurosis',
             'waves'      => 'wave',
             'oases'      => 'oasis',
-            'avalanches' => 'avalanche'
         )
     );
 

--- a/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
+++ b/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
@@ -25,6 +25,7 @@ class InflectorTest extends TestCase
             array('aquarium', 'aquaria'),
             array('arch', 'arches'),
             array('atlas', 'atlases'),
+            array('avalanche', 'avalanches'),
             array('axe', 'axes'),
             array('baby', 'babies'),
             array('bacillus', 'bacilli'),


### PR DESCRIPTION
Adds tests for #34