### PR TITLE
Add Uninflected *ia Words to Plural Rules

### DIFF
--- a/lib/Doctrine/Common/Inflector/Inflector.php
+++ b/lib/Doctrine/Common/Inflector/Inflector.php
@@ -71,7 +71,7 @@ class Inflector
             'people',
             'cookie',
             'police',
-            'trivia'
+            'trivia',
         ],
         'irregular' => [
             'atlas' => 'atlases',
@@ -207,7 +207,7 @@ class Inflector
             'utopia',
             'sepia',
             'mafia',
-            'fascia'
+            'fascia',
         ],
         'irregular' => [
             'abuses'     => 'abuse',

--- a/lib/Doctrine/Common/Inflector/Inflector.php
+++ b/lib/Doctrine/Common/Inflector/Inflector.php
@@ -71,6 +71,7 @@ class Inflector
             'people',
             'cookie',
             'police',
+            'trivia'
         ],
         'irregular' => [
             'atlas' => 'atlases',
@@ -198,6 +199,15 @@ class Inflector
             'police',
             'pants',
             'clothes',
+            'fuchsia',
+            'militia',
+            'galleria',
+            'petunia',
+            'trivia',
+            'utopia',
+            'sepia',
+            'mafia',
+            'fascia'
         ],
         'irregular' => [
             'abuses'     => 'abuse',

--- a/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
+++ b/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
@@ -298,7 +298,7 @@ class InflectorTest extends TestCase
             ['utopia', 'utopium'],
             ['sepia', 'sepium'],
             ['mafia', 'mafium'],
-            ['fascia', 'fascium']
+            ['fascia', 'fascium'],
         ];
     }
 

--- a/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
+++ b/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
@@ -73,6 +73,7 @@ class InflectorTest extends TestCase
             ['food_menu', 'food_menus'],
             ['FoodMenu', 'FoodMenus'],
             ['foot', 'feet'],
+            ['fuchsia', 'fuchsias'],
             ['fungus', 'fungi'],
             ['goose', 'geese'],
             ['glove', 'gloves'],
@@ -101,6 +102,7 @@ class InflectorTest extends TestCase
             ['menu', 'menus'],
             ['Menu', 'Menus'],
             ['mess', 'messes'],
+            ['militia', 'militias'],
             ['moose', 'moose'],
             ['motto', 'mottoes'],
             ['mouse', 'mice'],
@@ -257,6 +259,7 @@ class InflectorTest extends TestCase
             ['staff', 'staff'],
             ['swine', 'swine'],
             ['traffic', 'traffic'],
+            ['trivia', 'trivia'],
             ['trousers', 'trousers'],
             ['trout', 'trout'],
             ['tuna', 'tuna'],
@@ -270,6 +273,32 @@ class InflectorTest extends TestCase
             // Regex uninflected words
             ['sea bass', 'sea bass'],
             ['sea-bass', 'sea-bass'],
+        ];
+    }
+
+    /**
+     * Singulars as Plural test data.
+     *
+     * A list of singulars that should not yield the given result if passed through `singularize`.
+     * Returns an array of sample words.
+     *
+     * @return string[][]
+     */
+    public function dataSingularsUninflectedWhenSingularized() : array
+    {
+        Inflector::reset();
+
+        // In the format array('singular', 'notEquals')
+        return [
+            ['fuchsia', 'fuchsium'],
+            ['militia', 'militium'],
+            ['galleria', 'gallerium'],
+            ['petunia', 'petunium'],
+            ['trivia', 'trivium'],
+            ['utopia', 'utopium'],
+            ['sepia', 'sepium'],
+            ['mafia', 'mafium'],
+            ['fascia', 'fascium']
         ];
     }
 
@@ -294,6 +323,18 @@ class InflectorTest extends TestCase
             $plural,
             Inflector::pluralize($singular),
             sprintf("'%s' should be pluralized to '%s'", $singular, $plural)
+        );
+    }
+
+    /**
+     * @dataProvider dataSingularsUninflectedWhenSingularized
+     */
+    public function testSingularsWhenSingularizedShouldBeUninflected(string $singular, string $notEquals) : void
+    {
+        $this->assertNotEquals(
+            $notEquals,
+            Inflector::singularize($singular),
+            sprintf("'%s' should not be singularized to '%s'", $singular, $notEquals)
         );
     }
 


### PR DESCRIPTION
Some words that end in 'ia', when singularized, will result in a word ending in 'ium', which is incorrect.

Also added a test that will check that singular 'ia' words when singularized won't yield 'ium' words.