### PR TITLE
Add Uninflected *ia Words to Plural Rules

### DIFF
--- a/lib/Doctrine/Inflector/Rules/English/Uninflected.php
+++ b/lib/Doctrine/Inflector/Rules/English/Uninflected.php
@@ -18,7 +18,16 @@ final class Uninflected
         yield new Pattern('.*ss');
         yield new Pattern('clothes');
         yield new Pattern('data');
+        yield new Pattern('fascia');
+        yield new Pattern('fuchsia');
+        yield new Pattern('galleria');
+        yield new Pattern('mafia');
+        yield new Pattern('militia');
         yield new Pattern('pants');
+        yield new Pattern('petunia');
+        yield new Pattern('sepia');
+        yield new Pattern('trivia');
+        yield new Pattern('utopia');
     }
 
     /**
@@ -29,6 +38,7 @@ final class Uninflected
         yield from self::getDefault();
 
         yield new Pattern('people');
+        yield new Pattern('trivia');
         yield new Pattern('\w+ware$');
     }
 

--- a/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
@@ -8,6 +8,7 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Inflector\Language;
 use Doctrine\Tests\Inflector\Rules\LanguageFunctionalTest;
+use function sprintf;
 
 class EnglishFunctionalTest extends LanguageFunctionalTest
 {
@@ -456,7 +457,7 @@ class EnglishFunctionalTest extends LanguageFunctionalTest
             ['utopia', 'utopium'],
             ['sepia', 'sepium'],
             ['mafia', 'mafium'],
-            ['fascia', 'fascium']
+            ['fascia', 'fascium'],
         ];
     }
 

--- a/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
@@ -397,6 +397,7 @@ class EnglishFunctionalTest extends LanguageFunctionalTest
             ['traffic', 'traffic'],
             ['traffic', 'traffic'],
             ['travel', 'travel'],
+            ['trivia', 'trivia'],
             ['trousers', 'trousers'],
             ['trousers', 'trousers'],
             ['trout', 'trout'],
@@ -433,6 +434,42 @@ class EnglishFunctionalTest extends LanguageFunctionalTest
             ['zombie', 'zombies'],
             ['|ice', '|ices'],
         ];
+    }
+
+    /**
+     * Singulars as Plural test data.
+     *
+     * A list of singulars that should not yield the given result if passed through `singularize`.
+     * Returns an array of sample words.
+     *
+     * @return string[][]
+     */
+    public function dataSingularsUninflectedWhenSingularized() : array
+    {
+        // In the format array('singular', 'notEquals')
+        return [
+            ['fuchsia', 'fuchsium'],
+            ['militia', 'militium'],
+            ['galleria', 'gallerium'],
+            ['petunia', 'petunium'],
+            ['trivia', 'trivium'],
+            ['utopia', 'utopium'],
+            ['sepia', 'sepium'],
+            ['mafia', 'mafium'],
+            ['fascia', 'fascium']
+        ];
+    }
+
+    /**
+     * @dataProvider dataSingularsUninflectedWhenSingularized
+     */
+    public function testSingularsWhenSingularizedShouldBeUninflected(string $singular, string $notEquals) : void
+    {
+        self::assertNotSame(
+            $notEquals,
+            $this->createInflector()->singularize($singular),
+            sprintf("'%s' should not be singularized to '%s'", $singular, $notEquals)
+        );
     }
 
     protected function createInflector() : Inflector


### PR DESCRIPTION
Some words that end in 'ia', when singularized, will result in a word ending in 'ium', which is incorrect.

Also added a test that will check that singular 'ia' words when singularized won't yield 'ium' words.