### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ cache:
 
 php:
   - 7.1
-  - nightly
-
-allowed_failures:
-  - nightly
+  - 7.2
+  - 7.3
 
 install:
   - composer install -n


### PR DESCRIPTION
Removes nightly as most packages don't allow installing on PHP 8, adds PHP 7.2 and 7.3 to the build pipeline.