### PR TITLE
Add a BC layer for Inflector 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,16 @@
         "phpunit/phpunit": "^7.0"
     },
     "autoload": {
-        "psr-4": { "Doctrine\\Inflector\\": "lib/Doctrine/Inflector" }
+        "psr-4": {
+            "Doctrine\\Common\\Inflector\\": "lib/Doctrine/Common/Inflector",
+            "Doctrine\\Inflector\\": "lib/Doctrine/Inflector"
+        }
     },
     "autoload-dev": {
-        "psr-4": { "Doctrine\\Tests\\Inflector\\": "tests/Doctrine/Tests/Inflector" }
+        "psr-4": {
+            "Doctrine\\Tests\\Common\\Inflector\\": "tests/Doctrine/Tests/Common/Inflector",
+            "Doctrine\\Tests\\Inflector\\": "tests/Doctrine/Tests/Inflector"
+        }
     },
     "extra": {
         "branch-alias": {

--- a/lib/Doctrine/Common/Inflector/Inflector.php
+++ b/lib/Doctrine/Common/Inflector/Inflector.php
@@ -1,0 +1,185 @@
+<?php
+/*
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * This software consists of voluntary contributions made by many individuals
+ * and is licensed under the MIT license. For more information, see
+ * <http://www.doctrine-project.org>.
+ */
+
+namespace Doctrine\Common\Inflector;
+
+use BadMethodCallException;
+use Doctrine\Inflector\Inflector as InflectorObject;
+use Doctrine\Inflector\InflectorFactory;
+use Doctrine\Inflector\Language;
+use function sprintf;
+use function trigger_error;
+use const E_USER_DEPRECATED;
+
+/**
+ * @deprecated
+ */
+final class Inflector
+{
+    /** @var InflectorObject|null */
+    private static $instance;
+
+    private static function getInstance() : InflectorObject
+    {
+        if (self::$instance === null) {
+            self::$instance = (new InflectorFactory())(Language::ENGLISH);
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Converts a word into the format for a Doctrine table name. Converts 'ModelName' to 'model_name'.
+     *
+     * @deprecated
+     */
+    public static function tableize(string $word) : string
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+
+        return self::getInstance()->tableize($word);
+    }
+
+    /**
+     * Converts a word into the format for a Doctrine class name. Converts 'table_name' to 'TableName'.
+     */
+    public static function classify(string $word) : string
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+
+        return self::getInstance()->classify($word);
+    }
+
+    /**
+     * Camelizes a word. This uses the classify() method and turns the first character to lowercase.
+     *
+     * @deprecated
+     */
+    public static function camelize(string $word) : string
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+
+        return self::getInstance()->camelize($word);
+    }
+
+    /**
+     * Uppercases words with configurable delimeters between words.
+     *
+     * Takes a string and capitalizes all of the words, like PHP's built-in
+     * ucwords function. This extends that behavior, however, by allowing the
+     * word delimeters to be configured, rather than only separating on
+     * whitespace.
+     *
+     * Here is an example:
+     * <code>
+     * <?php
+     * $string = 'top-o-the-morning to all_of_you!';
+     * echo \Doctrine\Common\Inflector\Inflector::ucwords($string);
+     * // Top-O-The-Morning To All_of_you!
+     *
+     * echo \Doctrine\Common\Inflector\Inflector::ucwords($string, '-_ ');
+     * // Top-O-The-Morning To All_Of_You!
+     * ?>
+     * </code>
+     *
+     * @param string $string The string to operate on.
+     * @param string $delimiters A list of word separators.
+     *
+     * @return string The string with all delimeter-separated words capitalized.
+     *
+     * @deprecated
+     */
+    public static function ucwords(string $string, string $delimiters = " \n\t\r\0\x0B-") : string
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please use the "ucwords" function instead.', __METHOD__), E_USER_DEPRECATED);
+
+        return ucwords($string, $delimiters);
+    }
+
+    /**
+     * Clears Inflectors inflected value caches, and resets the inflection
+     * rules to the initial values.
+     *
+     * @deprecated
+     */
+    public static function reset() : void
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+    }
+
+    /**
+     * Adds custom inflection $rules, of either 'plural' or 'singular' $type.
+     *
+     * ### Usage:
+     *
+     * {{{
+     * Inflector::rules('plural', array('/^(inflect)or$/i' => '\1ables'));
+     * Inflector::rules('plural', array(
+     *     'rules' => array('/^(inflect)ors$/i' => '\1ables'),
+     *     'uninflected' => array('dontinflectme'),
+     *     'irregular' => array('red' => 'redlings')
+     * ));
+     * }}}
+     *
+     * @param string  $type         The type of inflection, either 'plural' or 'singular'
+     * @param array|iterable $rules An array of rules to be added.
+     * @param boolean $reset        If true, will unset default inflections for all
+     *                              new rules that are being defined in $rules.
+     *
+     * @return void
+     *
+     * @deprecated
+     */
+    public static function rules(string $type, iterable $rules, bool $reset = false) : void
+    {
+        throw new BadMethodCallException('Adding custom rules is no longer supported in Doctrine Inflector 2.0.');
+    }
+
+    /**
+     * Returns a word in plural form.
+     *
+     * @param string $word The word in singular form.
+     *
+     * @return string The word in plural form.
+     *
+     * @deprecated
+     */
+    public static function pluralize(string $word) : string
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+
+        return self::getInstance()->pluralize($word);
+    }
+
+    /**
+     * Returns a word in singular form.
+     *
+     * @param string $word The word in plural form.
+     *
+     * @return string The word in singular form.
+     *
+     * @deprecated
+     */
+    public static function singularize(string $word) : string
+    {
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+
+        return self::getInstance()->singularize($word);
+    }
+}

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,5 +12,8 @@
     <file>lib</file>
     <file>tests</file>
 
-    <rule ref="Doctrine" />
+    <rule ref="Doctrine">
+        <exclude-pattern>lib/Doctrine/Common</exclude-pattern>
+        <exclude-pattern>tests/Doctrine/Tests/Common</exclude-pattern>
+    </rule>
 </ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,3 +8,6 @@ parameters:
     paths:
       - lib
       - tests
+
+    excludes_analyse:
+        - %rootDir%/../../../tests/Doctrine/Tests/Common/*

--- a/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
+++ b/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
@@ -1,0 +1,482 @@
+<?php
+
+namespace Doctrine\Tests\Common\Inflector;
+
+use Doctrine\Common\Inflector\Inflector;
+use PHPUnit\Framework\TestCase;
+
+class InflectorTest extends TestCase
+{
+    /**
+     * Singular & Plural test data. Returns an array of sample words.
+     *
+     * @return string[][]
+     */
+    public function dataSampleWords() : array
+    {
+        Inflector::reset();
+
+        // In the format array('singular', 'plural')
+        return array(
+            array('', ''),
+            array('Abuse', 'Abuses'),
+            array('AcceptanceCriterion', 'AcceptanceCriteria'),
+            array('Alias', 'Aliases'),
+            array('alumnus', 'alumni'),
+            array('analysis', 'analyses'),
+            array('aquarium', 'aquaria'),
+            array('arch', 'arches'),
+            array('atlas', 'atlases'),
+            array('avalanche', 'avalanches'),
+            array('axe', 'axes'),
+            array('baby', 'babies'),
+            array('bacillus', 'bacilli'),
+            array('bacterium', 'bacteria'),
+            array('bureau', 'bureaus'),
+            array('bus', 'buses'),
+            array('Bus', 'Buses'),
+            array('cache', 'caches'),
+            array('cactus', 'cacti'),
+            array('cafe', 'cafes'),
+            array('calf', 'calves'),
+            array('categoria', 'categorias'),
+            array('chateau', 'chateaux'),
+            array('cherry', 'cherries'),
+            array('child', 'children'),
+            array('church', 'churches'),
+            array('circus', 'circuses'),
+            array('city', 'cities'),
+            array('cod', 'cod'),
+            array('cookie', 'cookies'),
+            array('copy', 'copies'),
+            array('crisis', 'crises'),
+            array('criterion', 'criteria'),
+            array('curriculum', 'curricula'),
+            array('curve', 'curves'),
+            array('data', 'data'),
+            array('deer', 'deer'),
+            array('demo', 'demos'),
+            array('dictionary', 'dictionaries'),
+            array('domino', 'dominoes'),
+            array('dwarf', 'dwarves'),
+            array('echo', 'echoes'),
+            array('elf', 'elves'),
+            array('emphasis', 'emphases'),
+            array('family', 'families'),
+            array('fax', 'faxes'),
+            array('fish', 'fish'),
+            array('flush', 'flushes'),
+            array('fly', 'flies'),
+            array('focus', 'foci'),
+            array('foe', 'foes'),
+            array('food_menu', 'food_menus'),
+            array('FoodMenu', 'FoodMenus'),
+            array('foot', 'feet'),
+            array('fungus', 'fungi'),
+            array('goose', 'geese'),
+            array('glove', 'gloves'),
+            array('gulf', 'gulfs'),
+            array('grave', 'graves'),
+            array('half', 'halves'),
+            array('hero', 'heroes'),
+            array('hippopotamus', 'hippopotami'),
+            array('hoax', 'hoaxes'),
+            array('house', 'houses'),
+            array('human', 'humans'),
+            array('identity', 'identities'),
+            array('index', 'indices'),
+            array('iris', 'irises'),
+            array('kiss', 'kisses'),
+            array('knife', 'knives'),
+            array('larva', 'larvae'),
+            array('leaf', 'leaves'),
+            array('life', 'lives'),
+            array('loaf', 'loaves'),
+            array('man', 'men'),
+            array('matrix', 'matrices'),
+            array('matrix_row', 'matrix_rows'),
+            array('medium', 'media'),
+            array('memorandum', 'memoranda'),
+            array('menu', 'menus'),
+            array('Menu', 'Menus'),
+            array('mess', 'messes'),
+            array('moose', 'moose'),
+            array('motto', 'mottoes'),
+            array('mouse', 'mice'),
+            array('neurosis', 'neuroses'),
+            array('news', 'news'),
+            array('niveau', 'niveaux'),
+            array('NodeMedia', 'NodeMedia'),
+            array('nucleus', 'nuclei'),
+            array('oasis', 'oases'),
+            array('octopus', 'octopuses'),
+            array('pass', 'passes'),
+            array('passerby', 'passersby'),
+            array('person', 'people'),
+            array('plateau', 'plateaux'),
+            array('potato', 'potatoes'),
+            array('powerhouse', 'powerhouses'),
+            array('quiz', 'quizzes'),
+            array('radius', 'radii'),
+            array('reflex', 'reflexes'),
+            array('roof', 'roofs'),
+            array('runner-up', 'runners-up'),
+            array('scarf', 'scarves'),
+            array('scratch', 'scratches'),
+            array('series', 'series'),
+            array('sheep', 'sheep'),
+            array('shelf', 'shelves'),
+            array('shoe', 'shoes'),
+            array('son-in-law', 'sons-in-law'),
+            array('species', 'species'),
+            array('splash', 'splashes'),
+            array('spouse', 'spouses'),
+            array('spy', 'spies'),
+            array('stimulus', 'stimuli'),
+            array('stitch', 'stitches'),
+            array('story', 'stories'),
+            array('syllabus', 'syllabi'),
+            array('tax', 'taxes'),
+            array('terminus', 'termini'),
+            array('thesis', 'theses'),
+            array('thief', 'thieves'),
+            array('tomato', 'tomatoes'),
+            array('tooth', 'teeth'),
+            array('tornado', 'tornadoes'),
+            array('try', 'tries'),
+            array('vertex', 'vertices'),
+            array('virus', 'viri'),
+            array('valve', 'valves'),
+            array('volcano', 'volcanoes'),
+            array('wash', 'washes'),
+            array('watch', 'watches'),
+            array('wave', 'waves'),
+            array('wharf', 'wharves'),
+            array('wife', 'wives'),
+            array('woman', 'women'),
+            array('clothes', 'clothes'),
+            array('pants', 'pants'),
+            array('police', 'police'),
+            array('scissors', 'scissors'),
+            array('trousers', 'trousers'),
+            array('dive', 'dives'),
+            array('olive', 'olives'),
+            // Uninflected words possibly not defined under singular/plural rules
+            array("Amoyese", "Amoyese"),
+            array("audio", "audio"),
+            array("bison", "bison"),
+            array("Borghese", "Borghese"),
+            array("bream", "bream"),
+            array("breeches", "breeches"),
+            array("britches", "britches"),
+            array("buffalo", "buffalo"),
+            array("cantus", "cantus"),
+            array("carp", "carp"),
+            array("chassis", "chassis"),
+            array("clippers", "clippers"),
+            array("cod", "cod"),
+            array("coitus", "coitus"),
+            array("compensation", "compensation"),
+            array("Congoese", "Congoese"),
+            array("contretemps", "contretemps"),
+            array("coreopsis", "coreopsis"),
+            array("corps", "corps"),
+            array("data", "data"),
+            array("debris", "debris"),
+            array("deer", "deer"),
+            array("diabetes", "diabetes"),
+            array("djinn", "djinn"),
+            array("education", "education"),
+            array("eland", "eland"),
+            array("elk", "elk"),
+            array("emoji", "emoji"),
+            array("equipment", "equipment"),
+            array("evidence", "evidence"),
+            array("Faroese", "Faroese"),
+            array("feedback", "feedback"),
+            array("fish", "fish"),
+            array("flounder", "flounder"),
+            array("Foochowese", "Foochowese"),
+            array("Furniture", "Furniture"),
+            array("furniture", "furniture"),
+            array("gallows", "gallows"),
+            array("Genevese", "Genevese"),
+            array("Genoese", "Genoese"),
+            array("Gilbertese", "Gilbertese"),
+            array("gold", "gold"),
+            array("headquarters", "headquarters"),
+            array("herpes", "herpes"),
+            array("hijinks", "hijinks"),
+            array("Hottentotese", "Hottentotese"),
+            array("information", "information"),
+            array("innings", "innings"),
+            array("jackanapes", "jackanapes"),
+            array("jedi", "jedi"),
+            array("Kiplingese", "Kiplingese"),
+            array("knowledge", "knowledge"),
+            array("Kongoese", "Kongoese"),
+            array("love", "love"),
+            array("Lucchese", "Lucchese"),
+            array("Luggage", "Luggage"),
+            array("mackerel", "mackerel"),
+            array("Maltese", "Maltese"),
+            array("metadata", "metadata"),
+            array("mews", "mews"),
+            array("moose", "moose"),
+            array("mumps", "mumps"),
+            array("Nankingese", "Nankingese"),
+            array("news", "news"),
+            array("nexus", "nexus"),
+            array("Niasese", "Niasese"),
+            array("nutrition", "nutrition"),
+            array("offspring", "offspring"),
+            array("Pekingese", "Pekingese"),
+            array("Piedmontese", "Piedmontese"),
+            array("pincers", "pincers"),
+            array("Pistoiese", "Pistoiese"),
+            array("plankton", "plankton"),
+            array("pliers", "pliers"),
+            array("pokemon", "pokemon"),
+            array("police", "police"),
+            array("Portuguese", "Portuguese"),
+            array("proceedings", "proceedings"),
+            array("rabies", "rabies"),
+            array("rain", "rain"),
+            array("rhinoceros", "rhinoceros"),
+            array("rice", "rice"),
+            array("salmon", "salmon"),
+            array("Sarawakese", "Sarawakese"),
+            array("scissors", "scissors"),
+            array("series", "series"),
+            array("Shavese", "Shavese"),
+            array("shears", "shears"),
+            array("sheep", "sheep"),
+            array("siemens", "siemens"),
+            array("species", "species"),
+            array("staff", "staff"),
+            array("swine", "swine"),
+            array("traffic", "traffic"),
+            array("trousers", "trousers"),
+            array("trout", "trout"),
+            array("tuna", "tuna"),
+            array("us", "us"),
+            array("Vermontese", "Vermontese"),
+            array("Wenchowese", "Wenchowese"),
+            array("wheat", "wheat"),
+            array("whiting", "whiting"),
+            array("wildebeest", "wildebeest"),
+            array("Yengeese", "Yengeese"),
+            // Regex uninflected words
+            array("sea bass", "sea bass"),
+            array("sea-bass", "sea-bass"),                                                                                    
+        );
+    }
+
+    /**
+     * @dataProvider dataSampleWords
+     */
+    public function testInflectingSingulars(string $singular, string $plural) : void
+    {
+        $this->assertEquals(
+            $singular,
+            Inflector::singularize($plural),
+            "'$plural' should be singularized to '$singular'"
+        );
+    }
+
+    /**
+     * @dataProvider dataSampleWords
+     */
+    public function testInflectingPlurals(string $singular, string $plural) : void
+    {
+        $this->assertEquals(
+            $plural,
+            Inflector::pluralize($singular),
+            "'$singular' should be pluralized to '$plural'"
+        );
+    }
+
+    public function testCustomPluralRule() : void
+    {
+        $this->markTestSkipped('Custom rules are no longer supported');
+
+        Inflector::reset();
+        Inflector::rules('plural', array('/^(custom)$/i' => '\1izables'));
+
+        $this->assertEquals(Inflector::pluralize('custom'), 'customizables');
+
+        Inflector::rules('plural', array('uninflected' => array('uninflectable')));
+
+        $this->assertEquals(Inflector::pluralize('uninflectable'), 'uninflectable');
+
+        Inflector::rules('plural', array(
+            'rules' => array('/^(alert)$/i' => '\1ables'),
+            'uninflected' => array('noflect', 'abtuse'),
+            'irregular' => array('amaze' => 'amazable', 'phone' => 'phonezes')
+        ));
+
+        $this->assertEquals(Inflector::pluralize('noflect'), 'noflect');
+        $this->assertEquals(Inflector::pluralize('abtuse'), 'abtuse');
+        $this->assertEquals(Inflector::pluralize('alert'), 'alertables');
+        $this->assertEquals(Inflector::pluralize('amaze'), 'amazable');
+        $this->assertEquals(Inflector::pluralize('phone'), 'phonezes');
+    }
+
+    public function testCustomSingularRule() : void
+    {
+        $this->markTestSkipped('Custom rules are no longer supported');
+
+        Inflector::reset();
+        Inflector::rules('singular', array('/(eple)r$/i' => '\1', '/(jente)r$/i' => '\1'));
+
+        $this->assertEquals(Inflector::singularize('epler'), 'eple');
+        $this->assertEquals(Inflector::singularize('jenter'), 'jente');
+
+        Inflector::rules('singular', array(
+            'rules' => array('/^(bil)er$/i' => '\1', '/^(inflec|contribu)tors$/i' => '\1ta'),
+            'uninflected' => array('singulars'),
+            'irregular' => array('spins' => 'spinor')
+        ));
+
+        $this->assertEquals(Inflector::singularize('inflectors'), 'inflecta');
+        $this->assertEquals(Inflector::singularize('contributors'), 'contributa');
+        $this->assertEquals(Inflector::singularize('spins'), 'spinor');
+        $this->assertEquals(Inflector::singularize('singulars'), 'singulars');
+    }
+
+    public function testSettingNewRulesClearsCaches() : void
+    {
+        $this->markTestSkipped('Custom rules are no longer supported');
+
+        Inflector::reset();
+
+        $this->assertEquals(Inflector::singularize('Bananas'), 'Banana');
+        $this->assertEquals(Inflector::pluralize('Banana'), 'Bananas');
+
+        Inflector::rules('singular', array(
+            'rules' => array('/(.*)nas$/i' => '\1zzz')
+        ));
+
+        $this->assertEquals('Banazzz', Inflector::singularize('Bananas'), 'Was inflected with old rules.');
+
+        Inflector::rules('plural', array(
+            'rules' => array('/(.*)na$/i' => '\1zzz'),
+            'irregular' => array('corpus' => 'corpora')
+        ));
+
+        $this->assertEquals(Inflector::pluralize('Banana'), 'Banazzz', 'Was inflected with old rules.');
+        $this->assertEquals(Inflector::pluralize('corpus'), 'corpora', 'Was inflected with old irregular form.');
+    }
+
+    public function testCustomRuleWithReset() : void
+    {
+        $this->markTestSkipped('Custom rules are no longer supported');
+
+        Inflector::reset();
+
+        $uninflected = array('atlas', 'lapis', 'onibus', 'pires', 'virus', '.*x');
+        $pluralIrregular = array('as' => 'ases');
+
+        Inflector::rules('singular', array(
+            'rules' => array('/^(.*)(a|e|o|u)is$/i' => '\1\2l'),
+            'uninflected' => $uninflected,
+        ), true);
+
+        Inflector::rules('plural', array(
+            'rules' => array(
+                '/^(.*)(a|e|o|u)l$/i' => '\1\2is',
+            ),
+            'uninflected' => $uninflected,
+            'irregular' => $pluralIrregular
+        ), true);
+
+        $this->assertEquals(Inflector::pluralize('Alcool'), 'Alcoois');
+        $this->assertEquals(Inflector::pluralize('Atlas'), 'Atlas');
+        $this->assertEquals(Inflector::singularize('Alcoois'), 'Alcool');
+        $this->assertEquals(Inflector::singularize('Atlas'), 'Atlas');
+    }
+
+    public function testUcwords() : void
+    {
+        $this->assertSame('Top-O-The-Morning To All_of_you!', Inflector::ucwords( 'top-o-the-morning to all_of_you!'));
+    }
+
+    public function testUcwordsWithCustomDelimeters() : void
+    {
+        $this->assertSame('Top-O-The-Morning To All_Of_You!', Inflector::ucwords( 'top-o-the-morning to all_of_you!', '-_ '));
+    }
+
+    /**
+     * @dataProvider dataStringsTableize
+     */
+    public function testTableize(string $expected, string $word) : void
+    {
+        $this->assertSame($expected, Inflector::tableize($word));
+    }
+
+    /**
+     * Strings which are used for testTableize.
+     *
+     * @return string[][]
+     */
+    public function dataStringsTableize() : array
+    {
+        // In the format array('expected', 'word')
+        return array(
+            array('', ''),
+            array('foo_bar', 'FooBar'),
+            array('f0o_bar', 'F0oBar'),
+        );
+    }
+
+    /**
+     * @dataProvider dataStringsClassify
+     */
+    public function testClassify(string $expected, string $word) : void
+    {
+        $this->assertSame($expected, Inflector::classify($word));
+    }
+
+    /**
+     * Strings which are used for testClassify.
+     *
+     * @return string[][]
+     */
+    public function dataStringsClassify() : array
+    {
+        // In the format array('expected', 'word')
+        return array(
+            array('', ''),
+            array('FooBar', 'foo_bar'),
+            array('FooBar', 'foo bar'),
+            array('F0oBar', 'f0o bar'),
+            array('F0oBar', 'f0o  bar'),
+            array('FooBar', 'foo_bar_'),
+        );
+    }
+
+    /**
+     * @dataProvider dataStringsCamelize
+     */
+    public function testCamelize(string $expected, string $word) : void
+    {
+        $this->assertSame($expected, Inflector::camelize($word));
+    }
+
+    /**
+     * Strings which are used for testCamelize.
+     *
+     * @return string[][]
+     */
+    public function dataStringsCamelize() : array
+    {
+        // In the format array('expected', 'word')
+        return array(
+            array('', ''),
+            array('fooBar', 'foo_bar'),
+            array('fooBar', 'foo bar'),
+            array('f0oBar', 'f0o bar'),
+            array('f0oBar', 'f0o  bar'),
+        );
+    }
+}


### PR DESCRIPTION
With around 150k downloads per day (according to Packagist), Inflector 1.x is a very popular package, with some large Open-Source projects depending on it. While we are working on 2.0, releasing it into the wild can cause a load of problems for our users: as soon as one library updates to Inflector 2.0, users may end up in dependency hell because it forces other libraries to update as well.

To ease the transition to the new API of Inflector 2.0, this PR adds a backward compatibility layer to provide the 1.x API in 2.0. This allows for a staggered upgrade, where libraries first upgrade their composer dependency constraint to `"doctrine/inflector": "^1.3.0 || ^2.0"` while keeping the old API. Once enough of the large libraries have migrated (e.g. `doctrine/common`, `doctrine/orm`, laravel/framework, symfony/maker-bundle, they can start dropping support for 1.x and make use of the new API.

This allows users the choice of using the 2.0 API in their projects without having to wait for other libraries to upgrade to Inflector 2.0.

---

The BC layer is excluded from PHPStan and phpcs analysis to allow for easier merging up of the 1.x branches. This helps to make sure that all bug fixes made in 1.3.x were also ported to 2.0.

The old API is marked as `@deprecated` via PHPDoc comments, with all methods triggering `E_USER_DEPRECATED` errors to allow tracing their origin with the Symfony PHPUnit Bridge.

Note that support for custom rules is not part of the BC layer as it still needs to be implemented in 2.0 (see #100). The BC layer can be updated once custom rulesets are supported.