### PR TITLE
Add support for custom rules

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -24,21 +24,17 @@ the ``Doctrine\Inflector\InflectorFactory`` class:
 
     use Doctrine\Inflector\InflectorFactory;
 
-    $inflectorFactory = new InflectorFactory();
-
-    $inflector = $inflectorFactory();
+    $inflector = InflectorFactory::create()->build();
 
 By default it will create an English inflector. If you want to use another language, just pass the language
-you want to create an inflector for to the ``create()`` method:
+you want to create an inflector for to the ``createForLanguage()`` method:
 
 .. code-block:: php
 
     use Doctrine\Inflector\InflectorFactory;
     use Doctrine\Inflector\Language;
 
-    $inflectorFactory = new InflectorFactory();
-
-    $inflector = $inflectorFactory(Language::SPANISH);
+    $inflector = InflectorFactory::createForLanguage(Language::SPANISH)->build();
 
 The supported languages are as follows:
 
@@ -78,12 +74,11 @@ Once you have done this, send a pull request to the ``doctrine/inflector`` repos
 Custom Setup
 ============
 
-If you want to setup custom singular and plural rules, you can configure the inflector like this.
+If you want to setup custom singular and plural rules, you can configure these in the factory:
 
 .. code-block:: php
 
-    use Doctrine\Inflector\CachedWordInflector;
-    use Doctrine\Inflector\Inflector;
+    use Doctrine\Inflector\InflectorFactory;
     use Doctrine\Inflector\Rules\Pattern;
     use Doctrine\Inflector\Rules\Patterns;
     use Doctrine\Inflector\Rules\Ruleset;
@@ -92,10 +87,9 @@ If you want to setup custom singular and plural rules, you can configure the inf
     use Doctrine\Inflector\Rules\Transformation;
     use Doctrine\Inflector\Rules\Transformations;
     use Doctrine\Inflector\Rules\Word;
-    use Doctrine\Inflector\RulesetInflector;
 
-    $inflector = new Inflector(
-        new CachedWordInflector(new RulesetInflector(
+    $inflector = InflectorFactory::create()
+        ->withSingularRules(
             new Ruleset(
                 new Transformations(
                     new Transformation(new Pattern('/^(bil)er$/i'), '\1'),
@@ -104,8 +98,8 @@ If you want to setup custom singular and plural rules, you can configure the inf
                 new Patterns(new Pattern('singulars')),
                 new Substitutions(new Substitution(new Word('spins'), new Word('spinor')))
             )
-        )),
-        new CachedWordInflector(new RulesetInflector(
+        )
+        ->withPluralRules(
             new Ruleset(
                 new Transformations(
                     new Transformation(new Pattern('^(bil)er$'), '\1'),
@@ -117,8 +111,8 @@ If you want to setup custom singular and plural rules, you can configure the inf
                     new Substitution(new Word('phone'), new Word('phonezes'))
                 )
             )
-        ))
-    );
+        )
+        ->build();
 
 No operation inflector
 ----------------------
@@ -215,6 +209,12 @@ You can unaccent a string of text using the ``unaccent()`` method:
 .. code-block:: php
 
     echo $inflector->unaccent('año'); // ano
+
+Legacy API
+==========
+
+The API present in Inflector 1.x is still available, but will be deprecated in a future release and dropped for 3.0.
+Support for languages other than English is available in the 2.0 API only.
 
 Acknowledgements
 ================

--- a/lib/Doctrine/Common/Inflector/Inflector.php
+++ b/lib/Doctrine/Common/Inflector/Inflector.php
@@ -22,7 +22,6 @@ namespace Doctrine\Common\Inflector;
 use BadMethodCallException;
 use Doctrine\Inflector\Inflector as InflectorObject;
 use Doctrine\Inflector\InflectorFactory;
-use Doctrine\Inflector\Language;
 use function sprintf;
 use function trigger_error;
 use const E_USER_DEPRECATED;
@@ -38,7 +37,7 @@ final class Inflector
     private static function getInstance() : InflectorObject
     {
         if (self::$instance === null) {
-            self::$instance = (new InflectorFactory())(Language::ENGLISH);
+            self::$instance = InflectorFactory::create()->build();
         }
 
         return self::$instance;

--- a/lib/Doctrine/Common/Inflector/Inflector.php
+++ b/lib/Doctrine/Common/Inflector/Inflector.php
@@ -19,9 +19,22 @@
 
 namespace Doctrine\Common\Inflector;
 
-use BadMethodCallException;
 use Doctrine\Inflector\Inflector as InflectorObject;
 use Doctrine\Inflector\InflectorFactory;
+use Doctrine\Inflector\LanguageInflectorFactory;
+use Doctrine\Inflector\Rules\Pattern;
+use Doctrine\Inflector\Rules\Patterns;
+use Doctrine\Inflector\Rules\Ruleset;
+use Doctrine\Inflector\Rules\Substitution;
+use Doctrine\Inflector\Rules\Substitutions;
+use Doctrine\Inflector\Rules\Transformation;
+use Doctrine\Inflector\Rules\Transformations;
+use Doctrine\Inflector\Rules\Word;
+use InvalidArgumentException;
+use function array_keys;
+use function array_map;
+use function array_unshift;
+use function array_values;
 use function sprintf;
 use function trigger_error;
 use const E_USER_DEPRECATED;
@@ -31,16 +44,30 @@ use const E_USER_DEPRECATED;
  */
 final class Inflector
 {
+    /**
+     * @var LanguageInflectorFactory|null
+     */
+    private static $factory;
+
     /** @var InflectorObject|null */
     private static $instance;
 
     private static function getInstance() : InflectorObject
     {
+        if (self::$factory === null) {
+            self::$factory = self::createFactory();
+        }
+
         if (self::$instance === null) {
-            self::$instance = InflectorFactory::create()->build();
+            self::$instance = self::$factory->build();
         }
 
         return self::$instance;
+    }
+
+    private static function createFactory() : LanguageInflectorFactory
+    {
+        return InflectorFactory::create();
     }
 
     /**
@@ -120,6 +147,9 @@ final class Inflector
     public static function reset() : void
     {
         @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+
+        self::$factory = null;
+        self::$instance = null;
     }
 
     /**
@@ -147,7 +177,74 @@ final class Inflector
      */
     public static function rules(string $type, iterable $rules, bool $reset = false) : void
     {
-        throw new BadMethodCallException('Adding custom rules is no longer supported in Doctrine Inflector 2.0.');
+        @trigger_error(sprintf('The "%s" method is deprecated and will be dropped in Doctrine Inflector 3.0. Please update to the new Inflector API.', __METHOD__), E_USER_DEPRECATED);
+
+        if (self::$factory === null) {
+            self::$factory = self::createFactory();
+        }
+
+        self::$instance = null;
+
+        switch ($type) {
+            case 'singular':
+                self::$factory->withSingularRules(self::buildRuleset($rules), $reset);
+                break;
+            case 'plural':
+                self::$factory->withPluralRules(self::buildRuleset($rules), $reset);
+                break;
+            default:
+                throw new InvalidArgumentException(sprintf('Cannot define custom inflection rules for type "%s".', $type));
+        }
+    }
+
+    private static function buildRuleset(iterable $rules) : Ruleset
+    {
+        $regular = [];
+        $irregular = [];
+        $uninflected = [];
+
+        foreach ($rules as $rule => $pattern) {
+            if ( ! is_array($pattern)) {
+                $regular[$rule] = $pattern;
+
+                continue;
+            }
+
+            switch ($rule) {
+                case 'uninflected':
+                    $uninflected = $pattern;
+                    break;
+                case 'irregular':
+                    $irregular = $pattern;
+                    break;
+                case 'rules':
+                    $regular = $pattern;
+                    break;
+            }
+        }
+
+        return new Ruleset(
+            new Transformations(...array_map(
+                static function (string $pattern, string $replacement) : Transformation {
+                    return new Transformation(new Pattern($pattern), $replacement);
+                },
+                array_keys($regular),
+                array_values($regular)
+            )),
+            new Patterns(...array_map(
+                static function (string $pattern) : Pattern {
+                    return new Pattern($pattern);
+                },
+                $uninflected
+            )),
+            new Substitutions(...array_map(
+                static function (string $word, string $to) : Substitution {
+                    return new Substitution(new Word($word), new Word($to));
+                },
+                array_keys($irregular),
+                array_values($irregular)
+            ))
+        );
     }
 
     /**

--- a/lib/Doctrine/Inflector/GenericLanguageInflectorFactory.php
+++ b/lib/Doctrine/Inflector/GenericLanguageInflectorFactory.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Inflector;
+
+use Doctrine\Inflector\Rules\Ruleset;
+use function array_unshift;
+
+abstract class GenericLanguageInflectorFactory implements LanguageInflectorFactory
+{
+    /** @var Ruleset[] */
+    private $singularRulesets = [];
+
+    /** @var Ruleset[] */
+    private $pluralRulesets = [];
+
+    final public function __construct()
+    {
+        $this->singularRulesets[] = $this->getSingularRuleset();
+        $this->pluralRulesets[]   = $this->getPluralRuleset();
+    }
+
+    final public function build() : Inflector
+    {
+        return new Inflector(
+            new CachedWordInflector(new RulesetInflector(
+                ...$this->singularRulesets
+            )),
+            new CachedWordInflector(new RulesetInflector(
+                ...$this->pluralRulesets
+            ))
+        );
+    }
+
+    final public function withSingularRules(?Ruleset $singularRules, bool $reset = false) : LanguageInflectorFactory
+    {
+        if ($reset) {
+            $this->singularRulesets = [];
+        }
+
+        if ($singularRules instanceof Ruleset) {
+            array_unshift($this->singularRulesets, $singularRules);
+        }
+
+        return $this;
+    }
+
+    final public function withPluralRules(?Ruleset $pluralRules, bool $reset = false) : LanguageInflectorFactory
+    {
+        if ($reset) {
+            $this->pluralRulesets = [];
+        }
+
+        if ($pluralRules instanceof Ruleset) {
+            array_unshift($this->pluralRulesets, $pluralRules);
+        }
+
+        return $this;
+    }
+
+    abstract protected function getSingularRuleset() : Ruleset;
+
+    abstract protected function getPluralRuleset() : Ruleset;
+}

--- a/lib/Doctrine/Inflector/InflectorFactory.php
+++ b/lib/Doctrine/Inflector/InflectorFactory.php
@@ -15,21 +15,26 @@ use function sprintf;
 
 final class InflectorFactory
 {
-    public function __invoke(string $language = Language::ENGLISH) : Inflector
+    public static function create() : LanguageInflectorFactory
+    {
+        return self::createForLanguage(Language::ENGLISH);
+    }
+
+    public static function createForLanguage(string $language) : LanguageInflectorFactory
     {
         switch ($language) {
             case Language::ENGLISH:
-                return (new English\InflectorFactory())();
+                return new English\InflectorFactory();
             case Language::FRENCH:
-                return (new French\InflectorFactory())();
+                return new French\InflectorFactory();
             case Language::NORWEGIAN_BOKMAL:
-                return (new NorwegianBokmal\InflectorFactory())();
+                return new NorwegianBokmal\InflectorFactory();
             case Language::PORTUGUESE:
-                return (new Portuguese\InflectorFactory())();
+                return new Portuguese\InflectorFactory();
             case Language::SPANISH:
-                return (new Spanish\InflectorFactory())();
+                return new Spanish\InflectorFactory();
             case Language::TURKISH:
-                return (new Turkish\InflectorFactory())();
+                return new Turkish\InflectorFactory();
             default:
                 throw new InvalidArgumentException(sprintf(
                     'Language "%s" is not supported.',

--- a/lib/Doctrine/Inflector/LanguageInflectorFactory.php
+++ b/lib/Doctrine/Inflector/LanguageInflectorFactory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Inflector;
+
+interface LanguageInflectorFactory
+{
+    /**
+     * Builds the inflector instance with all applicable rules
+     */
+    public function build() : Inflector;
+}

--- a/lib/Doctrine/Inflector/LanguageInflectorFactory.php
+++ b/lib/Doctrine/Inflector/LanguageInflectorFactory.php
@@ -4,8 +4,28 @@ declare(strict_types=1);
 
 namespace Doctrine\Inflector;
 
+use Doctrine\Inflector\Rules\Ruleset;
+
 interface LanguageInflectorFactory
 {
+    /**
+     * Applies custom rules for singularisation
+     *
+     * @param bool $reset If true, will unset default inflections for all new rules
+     *
+     * @return $this
+     */
+    public function withSingularRules(?Ruleset $singularRules, bool $reset = false) : self;
+
+    /**
+     * Applies custom rules for pluralisation
+     *
+     * @param bool $reset If true, will unset default inflections for all new rules
+     *
+     * @return $this
+     */
+    public function withPluralRules(?Ruleset $pluralRules, bool $reset = false) : self;
+
     /**
      * Builds the inflector instance with all applicable rules
      */

--- a/lib/Doctrine/Inflector/Rules/English/InflectorFactory.php
+++ b/lib/Doctrine/Inflector/Rules/English/InflectorFactory.php
@@ -4,22 +4,18 @@ declare(strict_types=1);
 
 namespace Doctrine\Inflector\Rules\English;
 
-use Doctrine\Inflector\CachedWordInflector;
-use Doctrine\Inflector\Inflector;
-use Doctrine\Inflector\LanguageInflectorFactory;
-use Doctrine\Inflector\RulesetInflector;
+use Doctrine\Inflector\GenericLanguageInflectorFactory;
+use Doctrine\Inflector\Rules\Ruleset;
 
-final class InflectorFactory implements LanguageInflectorFactory
+final class InflectorFactory extends GenericLanguageInflectorFactory
 {
-    public function build() : Inflector
+    protected function getSingularRuleset() : Ruleset
     {
-        return new Inflector(
-            new CachedWordInflector(new RulesetInflector(
-                Rules::getSingularRuleset()
-            )),
-            new CachedWordInflector(new RulesetInflector(
-                Rules::getPluralRuleset()
-            ))
-        );
+        return Rules::getSingularRuleset();
+    }
+
+    protected function getPluralRuleset() : Ruleset
+    {
+        return Rules::getPluralRuleset();
     }
 }

--- a/lib/Doctrine/Inflector/Rules/English/InflectorFactory.php
+++ b/lib/Doctrine/Inflector/Rules/English/InflectorFactory.php
@@ -6,11 +6,12 @@ namespace Doctrine\Inflector\Rules\English;
 
 use Doctrine\Inflector\CachedWordInflector;
 use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\LanguageInflectorFactory;
 use Doctrine\Inflector\RulesetInflector;
 
-final class InflectorFactory
+final class InflectorFactory implements LanguageInflectorFactory
 {
-    public function __invoke() : Inflector
+    public function build() : Inflector
     {
         return new Inflector(
             new CachedWordInflector(new RulesetInflector(

--- a/lib/Doctrine/Inflector/Rules/French/InflectorFactory.php
+++ b/lib/Doctrine/Inflector/Rules/French/InflectorFactory.php
@@ -4,22 +4,18 @@ declare(strict_types=1);
 
 namespace Doctrine\Inflector\Rules\French;
 
-use Doctrine\Inflector\CachedWordInflector;
-use Doctrine\Inflector\Inflector;
-use Doctrine\Inflector\LanguageInflectorFactory;
-use Doctrine\Inflector\RulesetInflector;
+use Doctrine\Inflector\GenericLanguageInflectorFactory;
+use Doctrine\Inflector\Rules\Ruleset;
 
-final class InflectorFactory implements LanguageInflectorFactory
+final class InflectorFactory extends GenericLanguageInflectorFactory
 {
-    public function build() : Inflector
+    protected function getSingularRuleset() : Ruleset
     {
-        return new Inflector(
-            new CachedWordInflector(new RulesetInflector(
-                Rules::getSingularRuleset()
-            )),
-            new CachedWordInflector(new RulesetInflector(
-                Rules::getPluralRuleset()
-            ))
-        );
+        return Rules::getSingularRuleset();
+    }
+
+    protected function getPluralRuleset() : Ruleset
+    {
+        return Rules::getPluralRuleset();
     }
 }

--- a/lib/Doctrine/Inflector/Rules/French/InflectorFactory.php
+++ b/lib/Doctrine/Inflector/Rules/French/InflectorFactory.php
@@ -6,11 +6,12 @@ namespace Doctrine\Inflector\Rules\French;
 
 use Doctrine\Inflector\CachedWordInflector;
 use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\LanguageInflectorFactory;
 use Doctrine\Inflector\RulesetInflector;
 
-final class InflectorFactory
+final class InflectorFactory implements LanguageInflectorFactory
 {
-    public function __invoke() : Inflector
+    public function build() : Inflector
     {
         return new Inflector(
             new CachedWordInflector(new RulesetInflector(

--- a/lib/Doctrine/Inflector/Rules/NorwegianBokmal/InflectorFactory.php
+++ b/lib/Doctrine/Inflector/Rules/NorwegianBokmal/InflectorFactory.php
@@ -4,22 +4,18 @@ declare(strict_types=1);
 
 namespace Doctrine\Inflector\Rules\NorwegianBokmal;
 
-use Doctrine\Inflector\CachedWordInflector;
-use Doctrine\Inflector\Inflector;
-use Doctrine\Inflector\LanguageInflectorFactory;
-use Doctrine\Inflector\RulesetInflector;
+use Doctrine\Inflector\GenericLanguageInflectorFactory;
+use Doctrine\Inflector\Rules\Ruleset;
 
-final class InflectorFactory implements LanguageInflectorFactory
+final class InflectorFactory extends GenericLanguageInflectorFactory
 {
-    public function build() : Inflector
+    protected function getSingularRuleset() : Ruleset
     {
-        return new Inflector(
-            new CachedWordInflector(new RulesetInflector(
-                Rules::getSingularRuleset()
-            )),
-            new CachedWordInflector(new RulesetInflector(
-                Rules::getPluralRuleset()
-            ))
-        );
+        return Rules::getSingularRuleset();
+    }
+
+    protected function getPluralRuleset() : Ruleset
+    {
+        return Rules::getPluralRuleset();
     }
 }

--- a/lib/Doctrine/Inflector/Rules/NorwegianBokmal/InflectorFactory.php
+++ b/lib/Doctrine/Inflector/Rules/NorwegianBokmal/InflectorFactory.php
@@ -6,11 +6,12 @@ namespace Doctrine\Inflector\Rules\NorwegianBokmal;
 
 use Doctrine\Inflector\CachedWordInflector;
 use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\LanguageInflectorFactory;
 use Doctrine\Inflector\RulesetInflector;
 
-final class InflectorFactory
+final class InflectorFactory implements LanguageInflectorFactory
 {
-    public function __invoke() : Inflector
+    public function build() : Inflector
     {
         return new Inflector(
             new CachedWordInflector(new RulesetInflector(

--- a/lib/Doctrine/Inflector/Rules/Portuguese/InflectorFactory.php
+++ b/lib/Doctrine/Inflector/Rules/Portuguese/InflectorFactory.php
@@ -4,22 +4,18 @@ declare(strict_types=1);
 
 namespace Doctrine\Inflector\Rules\Portuguese;
 
-use Doctrine\Inflector\CachedWordInflector;
-use Doctrine\Inflector\Inflector;
-use Doctrine\Inflector\LanguageInflectorFactory;
-use Doctrine\Inflector\RulesetInflector;
+use Doctrine\Inflector\GenericLanguageInflectorFactory;
+use Doctrine\Inflector\Rules\Ruleset;
 
-final class InflectorFactory implements LanguageInflectorFactory
+final class InflectorFactory extends GenericLanguageInflectorFactory
 {
-    public function build() : Inflector
+    protected function getSingularRuleset() : Ruleset
     {
-        return new Inflector(
-            new CachedWordInflector(new RulesetInflector(
-                Rules::getSingularRuleset()
-            )),
-            new CachedWordInflector(new RulesetInflector(
-                Rules::getPluralRuleset()
-            ))
-        );
+        return Rules::getSingularRuleset();
+    }
+
+    protected function getPluralRuleset() : Ruleset
+    {
+        return Rules::getPluralRuleset();
     }
 }

--- a/lib/Doctrine/Inflector/Rules/Portuguese/InflectorFactory.php
+++ b/lib/Doctrine/Inflector/Rules/Portuguese/InflectorFactory.php
@@ -6,11 +6,12 @@ namespace Doctrine\Inflector\Rules\Portuguese;
 
 use Doctrine\Inflector\CachedWordInflector;
 use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\LanguageInflectorFactory;
 use Doctrine\Inflector\RulesetInflector;
 
-final class InflectorFactory
+final class InflectorFactory implements LanguageInflectorFactory
 {
-    public function __invoke() : Inflector
+    public function build() : Inflector
     {
         return new Inflector(
             new CachedWordInflector(new RulesetInflector(

--- a/lib/Doctrine/Inflector/Rules/Spanish/InflectorFactory.php
+++ b/lib/Doctrine/Inflector/Rules/Spanish/InflectorFactory.php
@@ -6,11 +6,12 @@ namespace Doctrine\Inflector\Rules\Spanish;
 
 use Doctrine\Inflector\CachedWordInflector;
 use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\LanguageInflectorFactory;
 use Doctrine\Inflector\RulesetInflector;
 
-final class InflectorFactory
+final class InflectorFactory implements LanguageInflectorFactory
 {
-    public function __invoke() : Inflector
+    public function build() : Inflector
     {
         return new Inflector(
             new CachedWordInflector(new RulesetInflector(

--- a/lib/Doctrine/Inflector/Rules/Spanish/InflectorFactory.php
+++ b/lib/Doctrine/Inflector/Rules/Spanish/InflectorFactory.php
@@ -4,22 +4,18 @@ declare(strict_types=1);
 
 namespace Doctrine\Inflector\Rules\Spanish;
 
-use Doctrine\Inflector\CachedWordInflector;
-use Doctrine\Inflector\Inflector;
-use Doctrine\Inflector\LanguageInflectorFactory;
-use Doctrine\Inflector\RulesetInflector;
+use Doctrine\Inflector\GenericLanguageInflectorFactory;
+use Doctrine\Inflector\Rules\Ruleset;
 
-final class InflectorFactory implements LanguageInflectorFactory
+final class InflectorFactory extends GenericLanguageInflectorFactory
 {
-    public function build() : Inflector
+    protected function getSingularRuleset() : Ruleset
     {
-        return new Inflector(
-            new CachedWordInflector(new RulesetInflector(
-                Rules::getSingularRuleset()
-            )),
-            new CachedWordInflector(new RulesetInflector(
-                Rules::getPluralRuleset()
-            ))
-        );
+        return Rules::getSingularRuleset();
+    }
+
+    protected function getPluralRuleset() : Ruleset
+    {
+        return Rules::getPluralRuleset();
     }
 }

--- a/lib/Doctrine/Inflector/Rules/Turkish/InflectorFactory.php
+++ b/lib/Doctrine/Inflector/Rules/Turkish/InflectorFactory.php
@@ -4,22 +4,18 @@ declare(strict_types=1);
 
 namespace Doctrine\Inflector\Rules\Turkish;
 
-use Doctrine\Inflector\CachedWordInflector;
-use Doctrine\Inflector\Inflector;
-use Doctrine\Inflector\LanguageInflectorFactory;
-use Doctrine\Inflector\RulesetInflector;
+use Doctrine\Inflector\GenericLanguageInflectorFactory;
+use Doctrine\Inflector\Rules\Ruleset;
 
-final class InflectorFactory implements LanguageInflectorFactory
+final class InflectorFactory extends GenericLanguageInflectorFactory
 {
-    public function build() : Inflector
+    protected function getSingularRuleset() : Ruleset
     {
-        return new Inflector(
-            new CachedWordInflector(new RulesetInflector(
-                Rules::getSingularRuleset()
-            )),
-            new CachedWordInflector(new RulesetInflector(
-                Rules::getPluralRuleset()
-            ))
-        );
+        return Rules::getSingularRuleset();
+    }
+
+    protected function getPluralRuleset() : Ruleset
+    {
+        return Rules::getPluralRuleset();
     }
 }

--- a/lib/Doctrine/Inflector/Rules/Turkish/InflectorFactory.php
+++ b/lib/Doctrine/Inflector/Rules/Turkish/InflectorFactory.php
@@ -6,11 +6,12 @@ namespace Doctrine\Inflector\Rules\Turkish;
 
 use Doctrine\Inflector\CachedWordInflector;
 use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\LanguageInflectorFactory;
 use Doctrine\Inflector\RulesetInflector;
 
-final class InflectorFactory
+final class InflectorFactory implements LanguageInflectorFactory
 {
-    public function __invoke() : Inflector
+    public function build() : Inflector
     {
         return new Inflector(
             new CachedWordInflector(new RulesetInflector(

--- a/lib/Doctrine/Inflector/RulesetInflector.php
+++ b/lib/Doctrine/Inflector/RulesetInflector.php
@@ -6,7 +6,6 @@ namespace Doctrine\Inflector;
 
 use Doctrine\Inflector\Rules\Ruleset;
 use function array_merge;
-use function func_get_args;
 
 /**
  * Inflects based on multiple rulesets.

--- a/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
+++ b/tests/Doctrine/Tests/Common/Inflector/InflectorTest.php
@@ -300,8 +300,6 @@ class InflectorTest extends TestCase
 
     public function testCustomPluralRule() : void
     {
-        $this->markTestSkipped('Custom rules are no longer supported');
-
         Inflector::reset();
         Inflector::rules('plural', array('/^(custom)$/i' => '\1izables'));
 
@@ -326,8 +324,6 @@ class InflectorTest extends TestCase
 
     public function testCustomSingularRule() : void
     {
-        $this->markTestSkipped('Custom rules are no longer supported');
-
         Inflector::reset();
         Inflector::rules('singular', array('/(eple)r$/i' => '\1', '/(jente)r$/i' => '\1'));
 
@@ -348,8 +344,6 @@ class InflectorTest extends TestCase
 
     public function testSettingNewRulesClearsCaches() : void
     {
-        $this->markTestSkipped('Custom rules are no longer supported');
-
         Inflector::reset();
 
         $this->assertEquals(Inflector::singularize('Bananas'), 'Banana');
@@ -372,8 +366,6 @@ class InflectorTest extends TestCase
 
     public function testCustomRuleWithReset() : void
     {
-        $this->markTestSkipped('Custom rules are no longer supported');
-
         Inflector::reset();
 
         $uninflected = array('atlas', 'lapis', 'onibus', 'pires', 'virus', '.*x');

--- a/tests/Doctrine/Tests/Inflector/InflectorFactoryTest.php
+++ b/tests/Doctrine/Tests/Inflector/InflectorFactoryTest.php
@@ -5,16 +5,47 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Inflector;
 
 use Doctrine\Inflector\InflectorFactory;
+use Doctrine\Inflector\Language;
+use Doctrine\Inflector\Rules\English\InflectorFactory as EnglishInflectorFactory;
+use Doctrine\Inflector\Rules\French\InflectorFactory as FrenchInflectorFactory;
+use Doctrine\Inflector\Rules\NorwegianBokmal\InflectorFactory as NorwegianBokmalInflectorFactory;
+use Doctrine\Inflector\Rules\Portuguese\InflectorFactory as PortugueseInflectorFactory;
+use Doctrine\Inflector\Rules\Spanish\InflectorFactory as SpanishInflectorFactory;
+use Doctrine\Inflector\Rules\Turkish\InflectorFactory as TurkishInflectorFactory;
+use Generator;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class InflectorFactoryTest extends TestCase
 {
-    public function testCreateThrowsInvalidArgumentExceptionForUnsupportedLanguage() : void
+    public function testCreateUsesEnglishByDefault() : void
+    {
+        self::assertInstanceOf(EnglishInflectorFactory::class, InflectorFactory::create());
+    }
+
+    /**
+     * @dataProvider provideLanguages
+     */
+    public function testCreateForLanguageWithCustomLanguage(string $expectedClass, string $language) : void
+    {
+        self::assertInstanceOf($expectedClass, InflectorFactory::createForLanguage($language));
+    }
+
+    public static function provideLanguages() : Generator
+    {
+        yield 'English' => [EnglishInflectorFactory::class, Language::ENGLISH];
+        yield 'French' => [FrenchInflectorFactory::class, Language::FRENCH];
+        yield 'Norwegian Bokmal' => [NorwegianBokmalInflectorFactory::class, Language::NORWEGIAN_BOKMAL];
+        yield 'Portuguese' => [PortugueseInflectorFactory::class, Language::PORTUGUESE];
+        yield 'Spanish' => [SpanishInflectorFactory::class, Language::SPANISH];
+        yield 'Turkish' => [TurkishInflectorFactory::class, Language::TURKISH];
+    }
+
+    public function testCreateForLanguageThrowsInvalidArgumentExceptionForUnsupportedLanguage() : void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Language "invalid" is not supported.');
 
-        (new InflectorFactory())('invalid');
+        InflectorFactory::createForLanguage('invalid')->build();
     }
 }

--- a/tests/Doctrine/Tests/Inflector/InflectorFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/InflectorFunctionalTest.php
@@ -6,7 +6,6 @@ namespace Doctrine\Tests\Inflector;
 
 use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
-use Doctrine\Inflector\Language;
 use PHPUnit\Framework\TestCase;
 
 class InflectorFunctionalTest extends TestCase
@@ -103,6 +102,6 @@ class InflectorFunctionalTest extends TestCase
 
     private function createInflector() : Inflector
     {
-        return (new InflectorFactory())(Language::ENGLISH);
+        return InflectorFactory::create()->build();
     }
 }

--- a/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
@@ -476,6 +476,6 @@ class EnglishFunctionalTest extends LanguageFunctionalTest
 
     protected function createInflector() : Inflector
     {
-        return (new InflectorFactory())(Language::ENGLISH);
+        return InflectorFactory::createForLanguage(Language::ENGLISH)->build();
     }
 }

--- a/tests/Doctrine/Tests/Inflector/Rules/French/FrenchFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/French/FrenchFunctionalTest.php
@@ -58,6 +58,6 @@ class FrenchFunctionalTest extends LanguageFunctionalTest
 
     protected function createInflector() : Inflector
     {
-        return (new InflectorFactory())(Language::FRENCH);
+        return InflectorFactory::createForLanguage(Language::FRENCH)->build();
     }
 }

--- a/tests/Doctrine/Tests/Inflector/Rules/NorwegianBokmal/NorwegianBokmalFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/NorwegianBokmal/NorwegianBokmalFunctionalTest.php
@@ -33,6 +33,6 @@ class NorwegianBokmalFunctionalTest extends LanguageFunctionalTest
 
     protected function createInflector() : Inflector
     {
-        return (new InflectorFactory())(Language::NORWEGIAN_BOKMAL);
+        return InflectorFactory::createForLanguage(Language::NORWEGIAN_BOKMAL)->build();
     }
 }

--- a/tests/Doctrine/Tests/Inflector/Rules/Portuguese/PortugueseFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/Portuguese/PortugueseFunctionalTest.php
@@ -49,6 +49,6 @@ class PortugueseFunctionalTest extends LanguageFunctionalTest
 
     protected function createInflector() : Inflector
     {
-        return (new InflectorFactory())(Language::PORTUGUESE);
+        return InflectorFactory::createForLanguage(Language::PORTUGUESE)->build();
     }
 }

--- a/tests/Doctrine/Tests/Inflector/Rules/Spanish/SpanishFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/Spanish/SpanishFunctionalTest.php
@@ -58,6 +58,6 @@ class SpanishFunctionalTest extends LanguageFunctionalTest
 
     protected function createInflector() : Inflector
     {
-        return (new InflectorFactory())(Language::SPANISH);
+        return InflectorFactory::createForLanguage(Language::SPANISH)->build();
     }
 }

--- a/tests/Doctrine/Tests/Inflector/Rules/Turkish/TurkishFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/Turkish/TurkishFunctionalTest.php
@@ -31,6 +31,6 @@ class TurkishFunctionalTest extends LanguageFunctionalTest
 
     protected function createInflector() : Inflector
     {
-        return (new InflectorFactory())(Language::TURKISH);
+        return InflectorFactory::createForLanguage(Language::TURKISH)->build();
     }
 }


### PR DESCRIPTION
Fixes #100.

Custom rules were the last 1.x feature that was not present in 2.0. This PR adds support for this via two new methods to the builder: `withSingularRules` and `withPluralRules`. Both methods support a `$reset` (`false` by default) which can be used to disable any previous rules (e.g. language-specific rules).

Note: with this, work on 2.0 comes to a finish. However, this won't be 2.0, but rather 1.4.0. The process is as follows:

- Introduce new API in 1.4.0, keep legacy API as-is. Methods will be marked as `@deprecated` but will not cause "loud" deprecations via `@trigger_error`.
- Downstream Doctrine packages will be updated to allow for using `^1.4 || ^2.0`.
- Once the versions bringing this update is released, 1.5.0 and 2.0.0 will be released. 1.5.0 will deprecate the legacy API using `@trigger_error`.
