### PR TITLE
Fixed conversion of the word "status" to singular

### DIFF
--- a/lib/Doctrine/Inflector/Rules/English/Inflectible.php
+++ b/lib/Doctrine/Inflector/Rules/English/Inflectible.php
@@ -17,6 +17,7 @@ class Inflectible
     public static function getSingular() : iterable
     {
         yield new Transformation(new Pattern('(s)tatuses$'), '\1\2tatus');
+        yield new Transformation(new Pattern('(s)tatus$'), '\1\2tatus');
         yield new Transformation(new Pattern('^(.*)(menu)s$'), '\1\2');
         yield new Transformation(new Pattern('(quiz)zes$'), '\\1');
         yield new Transformation(new Pattern('(matr)ices$'), '\1ix');

--- a/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
@@ -459,6 +459,7 @@ class EnglishFunctionalTest extends LanguageFunctionalTest
             ['sepia', 'sepium'],
             ['mafia', 'mafium'],
             ['fascia', 'fascium'],
+            ['status', 'statu'],
         ];
     }
 


### PR DESCRIPTION
Now the conversion of the word "status" is as follows:
* `status` => `statu`

Adding a new rule fixes this error.