### PR TITLE
Fix handling of multiple rulesets

### DIFF
--- a/lib/Doctrine/Inflector/RulesetInflector.php
+++ b/lib/Doctrine/Inflector/RulesetInflector.php
@@ -36,17 +36,13 @@ class RulesetInflector implements WordInflector
             if ($ruleset->getUninflected()->matches($word)) {
                 return $word;
             }
-        }
 
-        foreach ($this->rulesets as $ruleset) {
             $inflected = $ruleset->getIrregular()->inflect($word);
 
             if ($inflected !== $word) {
                 return $inflected;
             }
-        }
 
-        foreach ($this->rulesets as $ruleset) {
             $inflected = $ruleset->getRegular()->inflect($word);
 
             if ($inflected !== $word) {


### PR DESCRIPTION
This fixes an issue where applying a custom inflection of a word that was on the "uninflected" list of another ruleset was not being applied. This allows people to override newly uninflected words such as "travel", "homework", "research", and potentially more.