### PR TITLE
fix "lieu" word pluralization

### DIFF
--- a/lib/Doctrine/Inflector/Rules/French/Inflectible.php
+++ b/lib/Doctrine/Inflector/Rules/French/Inflectible.php
@@ -32,8 +32,8 @@ class Inflectible
         yield new Transformation(new Pattern('/(b|cor|ém|gemm|soupir|trav|vant|vitr)ail$/'), '\1aux');
         yield new Transformation(new Pattern('/ail$/'), 'ails');
         yield new Transformation(new Pattern('/al$/'), 'aux');
-        yield new Transformation(new Pattern('/(bleu|émeu|landau|lieu|pneu|sarrau)$/'), '\1s');
-        yield new Transformation(new Pattern('/(bijou|caillou|chou|genou|hibou|joujou|pou|au|eu|eau)$/'), '\1x');
+        yield new Transformation(new Pattern('/(bleu|émeu|landau|pneu|sarrau)$/'), '\1s');
+        yield new Transformation(new Pattern('/(bijou|caillou|chou|genou|hibou|joujou|lieu|pou|au|eu|eau)$/'), '\1x');
         yield new Transformation(new Pattern('/$/'), 's');
     }
 

--- a/tests/Doctrine/Tests/Inflector/Rules/French/FrenchFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/French/FrenchFunctionalTest.php
@@ -37,7 +37,7 @@ class FrenchFunctionalTest extends LanguageFunctionalTest
             ['bleu', 'bleus'],
             ['émeu', 'émeus'],
             ['landau', 'landaus'],
-            ['lieu', 'lieus'],
+            ['lieu', 'lieux'],
             ['pneu', 'pneus'],
             ['sarrau', 'sarraus'],
             ['journal', 'journaux'],


### PR DESCRIPTION
The word "lieu" in french has different meaning but the most common use has a plural form with an "x" at the end.