### PR TITLE
Run require checks on push as well

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,6 +3,11 @@ name: "Continuous Integration"
 
 on:
   pull_request:
+    branches:
+      - "*.x"
+  push:
+    branches:
+      - "*.x"
 
 jobs:
   roave_bc_check:


### PR DESCRIPTION
Merge up PRs use branches pushed to the repository, and that does not
trigger the continous integration workflow.