### PR TITLE
withIrregulars method for InflectorFactory

### DIFF
--- a/lib/Doctrine/Inflector/GenericLanguageInflectorFactory.php
+++ b/lib/Doctrine/Inflector/GenericLanguageInflectorFactory.php
@@ -4,14 +4,15 @@ declare(strict_types=1);
 
 namespace Doctrine\Inflector;
 
-use Doctrine\Inflector\Rules\Ruleset;
-use Doctrine\Inflector\Rules\Word;
 use Doctrine\Inflector\Rules\Patterns;
+use Doctrine\Inflector\Rules\Ruleset;
 use Doctrine\Inflector\Rules\Substitution;
 use Doctrine\Inflector\Rules\Substitutions;
 use Doctrine\Inflector\Rules\Transformations;
+use Doctrine\Inflector\Rules\Word;
 
 use function array_unshift;
+use function is_array;
 
 abstract class GenericLanguageInflectorFactory implements LanguageInflectorFactory
 {
@@ -65,27 +66,29 @@ abstract class GenericLanguageInflectorFactory implements LanguageInflectorFacto
         return $this;
     }
 
-    final public function withIrregulars(array $irregulars, bool $reset = false): LanguageInflectorFactory
+    final public function withIrregulars(?array $irregulars, bool $reset = false): LanguageInflectorFactory
     {
         if ($reset) {
-            $this->pluralRulesets = [];
+            $this->pluralRulesets   = [];
             $this->singularRulesets = [];
         }
 
-        $newIrregulars = array();
-        foreach ($irregulars as $irregular) {
-            $newIrregulars[] = new Substitution(new Word($irregular[0]), new Word($irregular[1]));
+        if (is_array($irregulars)) {
+            $newIrregulars = [];
+            foreach ($irregulars as $irregular) {
+                $newIrregulars[] = new Substitution(new Word($irregular[0]), new Word($irregular[1]));
+            }
+
+            $transf   = new Transformations();
+            $patterns = new Patterns();
+            $substs   = new Substitutions(...$newIrregulars);
+
+            $plural   = new Ruleset($transf, $patterns, $substs);
+            $singular = new Ruleset($transf, $patterns, $substs->getFlippedSubstitutions());
+
+            array_unshift($this->pluralRulesets, $plural);
+            array_unshift($this->singularRulesets, $singular);
         }
-
-        $transf = new Transformations();
-        $patterns = new Patterns();
-        $substs = new Substitutions(...$newIrregulars);
-
-        $plural = new Ruleset($transf, $patterns, $substs);
-        $singular = new Ruleset($transf, $patterns, $substs->getFlippedSubstitutions());
-
-        array_unshift($this->pluralRulesets, $plural);
-        array_unshift($this->singularRulesets, $singular);
 
         return $this;
     }

--- a/lib/Doctrine/Inflector/LanguageInflectorFactory.php
+++ b/lib/Doctrine/Inflector/LanguageInflectorFactory.php
@@ -27,6 +27,15 @@ interface LanguageInflectorFactory
     public function withPluralRules(?Ruleset $pluralRules, bool $reset = false): self;
 
     /**
+     * Applies custom rules for irregular words
+     *
+     * @param bool $reset If true, will unset default inflections for all new rules
+     *
+     * @return $this
+     */
+    public function withIrregulars(array $irregulars, bool $reset = false): self;
+
+    /**
      * Builds the inflector instance with all applicable rules
      */
     public function build(): Inflector;

--- a/lib/Doctrine/Inflector/LanguageInflectorFactory.php
+++ b/lib/Doctrine/Inflector/LanguageInflectorFactory.php
@@ -29,11 +29,12 @@ interface LanguageInflectorFactory
     /**
      * Applies custom rules for irregular words
      *
-     * @param bool $reset If true, will unset default inflections for all new rules
+     * @param mixed[][] $irregulars Array of arrays of strings in the format [['singular', 'plural'], ...]
+     * @param bool      $reset      If true, will unset default inflections for all new rules
      *
      * @return $this
      */
-    public function withIrregulars(array $irregulars, bool $reset = false): self;
+    public function withIrregulars(?array $irregulars, bool $reset = false): self;
 
     /**
      * Builds the inflector instance with all applicable rules

--- a/tests/Doctrine/Tests/Inflector/InflectorWithIrregularsTest.php
+++ b/tests/Doctrine/Tests/Inflector/InflectorWithIrregularsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Inflector;
+
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
+use PHPUnit\Framework\TestCase;
+
+class InflectorWithIrregularsTest extends TestCase
+{
+    /** @var Inflector */
+    private $inflector;
+
+    /**
+     * @dataProvider dataIrregulars
+     */
+    public function testIrregulars(string $word, string $expected): void
+    {
+        self::assertSame($expected, $this->inflector->pluralize($word));
+        self::assertSame($word, $this->inflector->singularize($expected));
+    }
+    /**
+     * @dataProvider dataRegulars
+     */
+    public function testRegulars(string $word, string $expected): void
+    {
+        self::assertSame($expected, $this->inflector->pluralize($word));
+        self::assertSame($word, $this->inflector->singularize($expected));
+    }
+
+    /**
+     * Strings which are used for testTableize.
+     *
+     * @return string[][]
+     */
+    public function dataRegulars(): array
+    {
+        // In the format array('word', 'expected')
+        return [
+            ['address', 'addresses'],
+            ['advice', 'advice'],
+            ['agency', 'agencies'],
+            ['aircraft', 'aircraft'],
+            ['alias', 'aliases'],
+        ];
+    }
+
+    /**
+     * Strings which are used for testIrregulars.
+     *
+     * @return string[][]
+     */
+    public function dataIrregulars(): array
+    {
+        // In the format array('word', 'expected')
+        return [
+            ['foobar', 'barfoo'],
+            ['test', 'testz']
+        ];
+    }
+
+    protected function setUp(): void
+    {        
+        $this->inflector = InflectorFactory::create()->withIrregulars($this->dataIrregulars())->build();
+    }
+}

--- a/tests/Doctrine/Tests/Inflector/InflectorWithIrregularsTest.php
+++ b/tests/Doctrine/Tests/Inflector/InflectorWithIrregularsTest.php
@@ -21,6 +21,7 @@ class InflectorWithIrregularsTest extends TestCase
         self::assertSame($expected, $this->inflector->pluralize($word));
         self::assertSame($word, $this->inflector->singularize($expected));
     }
+
     /**
      * @dataProvider dataRegulars
      */
@@ -57,12 +58,12 @@ class InflectorWithIrregularsTest extends TestCase
         // In the format array('word', 'expected')
         return [
             ['foobar', 'barfoo'],
-            ['test', 'testz']
+            ['test', 'testz'],
         ];
     }
 
     protected function setUp(): void
-    {        
+    {
         $this->inflector = InflectorFactory::create()->withIrregulars($this->dataIrregulars())->build();
     }
 }


### PR DESCRIPTION
Adds a new method for the in `LanguageInflectorFactory` along with a test for it.
It allows to specify an array of custom Irregular substitutions:
```
$irregulars = [
   ['singular1', 'plural1'],
   ['singular2', 'plural2'],
   [...]
];

InflectorFactory::create()->withIrregulars($irregulars)->build();
```
Should be very useful when a given ruleset is not getting some word right, the user could manually set the words it needs