### PR TITLE
Add "is" to "are" irregular replacement

### DIFF
--- a/lib/Doctrine/Inflector/Rules/English/Inflectible.php
+++ b/lib/Doctrine/Inflector/Rules/English/Inflectible.php
@@ -122,6 +122,7 @@ class Inflectible
         yield new Substitution(new Word('hoof'), new Word('hoofs'));
         yield new Substitution(new Word('human'), new Word('humans'));
         yield new Substitution(new Word('iris'), new Word('irises'));
+        yield new Substitution(new Word('is'), new Word('are'));
         yield new Substitution(new Word('larva'), new Word('larvae'));
         yield new Substitution(new Word('leaf'), new Word('leaves'));
         yield new Substitution(new Word('lens'), new Word('lenses'));

--- a/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
@@ -169,6 +169,7 @@ class EnglishFunctionalTest extends LanguageFunctionalTest
             ['information', 'information'],
             ['innings', 'innings'],
             ['iris', 'irises'],
+            ['is', 'are'],
             ['jackanapes', 'jackanapes'],
             ['jeans', 'jeans'],
             ['jedi', 'jedi'],


### PR DESCRIPTION
For use in strings like "There **_is_** 1 staff member logged in" / "There **_are_** 2 staff members logged in".

Laravel blade example:
```
There {{ Str::plural('is', $count) }} {{ $count }} staff {{ Str::plural('member', $count) }} logged in
```