### PR TITLE
add "feet" to uninflected

### DIFF
--- a/lib/Doctrine/Inflector/Rules/English/Uninflected.php
+++ b/lib/Doctrine/Inflector/Rules/English/Uninflected.php
@@ -83,6 +83,7 @@ final class Uninflected
         yield new Pattern('equipment');
         yield new Pattern('evidence');
         yield new Pattern('faroese');
+        yield new Pattern('feet');
         yield new Pattern('feedback');
         yield new Pattern('fish');
         yield new Pattern('flounder');

--- a/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
@@ -121,6 +121,7 @@ class EnglishFunctionalTest extends LanguageFunctionalTest
             ['experience', 'experiences'],
             ['family', 'families'],
             ['faroese', 'faroese'],
+            ['foot', 'feet'],
             ['fax', 'faxes'],
             ['feedback', 'feedback'],
             ['fish', 'fish'],


### PR DESCRIPTION
`feet` currently pluralizes to `feets`. This PR corrects it to remain `feet` (plural of `foot`).

Found by Alex Debecker.