### PR TITLE
[Fix] Add `cave` to English irregulars

### DIFF
--- a/lib/Doctrine/Inflector/Rules/English/Inflectible.php
+++ b/lib/Doctrine/Inflector/Rules/English/Inflectible.php
@@ -98,6 +98,7 @@ class Inflectible
         yield new Substitution(new Word('blouse'), new Word('blouses'));
         yield new Substitution(new Word('brother'), new Word('brothers'));
         yield new Substitution(new Word('cafe'), new Word('cafes'));
+        yield new Substitution(new Word('cave'), new Word('caves'));
         yield new Substitution(new Word('chateau'), new Word('chateaux'));
         yield new Substitution(new Word('niveau'), new Word('niveaux'));
         yield new Substitution(new Word('child'), new Word('children'));

--- a/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
@@ -61,6 +61,7 @@ class EnglishFunctionalTest extends LanguageFunctionalTest
             ['canvas', 'canvases'],
             ['carp', 'carp'],
             ['case', 'cases'],
+            ['cave', 'caves'],
             ['categoria', 'categorias'],
             ['category', 'categories'],
             ['cattle', 'cattle'],


### PR DESCRIPTION
Hi, 
I struggled to understand why my Laravel router expected a `cafe` for my `caves` resource api. 😅

It's fixed!

Thanks.

A ca~f~ver.