### PR TITLE
add 'epoch' to irregular words list

### DIFF
--- a/lib/Doctrine/Inflector/Rules/English/Inflectible.php
+++ b/lib/Doctrine/Inflector/Rules/English/Inflectible.php
@@ -111,6 +111,7 @@ class Inflectible
         yield new Substitution(new Word('demo'), new Word('demos'));
         yield new Substitution(new Word('domino'), new Word('dominoes'));
         yield new Substitution(new Word('echo'), new Word('echoes'));
+        yield new Substitution(new Word('epoch'), new Word('epochs'));
         yield new Substitution(new Word('foot'), new Word('feet'));
         yield new Substitution(new Word('fungus'), new Word('fungi'));
         yield new Substitution(new Word('ganglion'), new Word('ganglions'));

--- a/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
@@ -117,6 +117,7 @@ class EnglishFunctionalTest extends LanguageFunctionalTest
             ['emphasis', 'emphases'],
             ['employee-child', 'employee-children'],
             ['energy', 'energies'],
+            ['epoch', 'epochs'],
             ['equipment', 'equipment'],
             ['evidence', 'evidence'],
             ['experience', 'experiences'],


### PR DESCRIPTION
Add irregular word 'epoch' to list. Reference: https://www.britannica.com/dictionary/epoch