### PR TITLE
Update Inflectible.php

### DIFF
--- a/lib/Doctrine/Inflector/Rules/English/Inflectible.php
+++ b/lib/Doctrine/Inflector/Rules/English/Inflectible.php
@@ -104,6 +104,7 @@ class Inflectible
         yield new Substitution(new Word('child'), new Word('children'));
         yield new Substitution(new Word('canvas'), new Word('canvases'));
         yield new Substitution(new Word('cookie'), new Word('cookies'));
+        yield new Substitution(new Word('brownie'), new Word('brownies'));
         yield new Substitution(new Word('corpus'), new Word('corpuses'));
         yield new Substitution(new Word('cow'), new Word('cows'));
         yield new Substitution(new Word('criterion'), new Word('criteria'));


### PR DESCRIPTION
"Brownies" has the same issue as "Cookies" previously had, where singularize returns `browny` not `brownies`. 