### PR TITLE
Correct singularization of brownies

### DIFF
--- a/lib/Doctrine/Inflector/Rules/English/Inflectible.php
+++ b/lib/Doctrine/Inflector/Rules/English/Inflectible.php
@@ -104,6 +104,7 @@ class Inflectible
         yield new Substitution(new Word('child'), new Word('children'));
         yield new Substitution(new Word('canvas'), new Word('canvases'));
         yield new Substitution(new Word('cookie'), new Word('cookies'));
+        yield new Substitution(new Word('brownie'), new Word('brownies'));
         yield new Substitution(new Word('corpus'), new Word('corpuses'));
         yield new Substitution(new Word('cow'), new Word('cows'));
         yield new Substitution(new Word('criterion'), new Word('criteria'));

--- a/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
@@ -83,6 +83,7 @@ class EnglishFunctionalTest extends LanguageFunctionalTest
             ['congoese', 'congoese'],
             ['contretemps', 'contretemps'],
             ['cookie', 'cookies'],
+            ['brownie', 'brownies'],
             ['copy', 'copies'],
             ['coreopsis', 'coreopsis'],
             ['corps', 'corps'],


### PR DESCRIPTION
Currently, `echo $inflector->singularize('brownies'); ` returns `browny`.

This pull request changes that to `brownie`