### PR TITLE
Correct pluralization of axis

### DIFF
--- a/lib/Doctrine/Inflector/Rules/English/Inflectible.php
+++ b/lib/Doctrine/Inflector/Rules/English/Inflectible.php
@@ -93,6 +93,7 @@ class Inflectible
     public static function getIrregular(): iterable
     {
         yield new Substitution(new Word('atlas'), new Word('atlases'));
+        yield new Substitution(new Word('axis'), new Word('axes'));
         yield new Substitution(new Word('axe'), new Word('axes'));
         yield new Substitution(new Word('beef'), new Word('beefs'));
         yield new Substitution(new Word('blouse'), new Word('blouses'));

--- a/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
+++ b/tests/Doctrine/Tests/Inflector/Rules/English/EnglishFunctionalTest.php
@@ -390,6 +390,7 @@ class EnglishFunctionalTest extends LanguageFunctionalTest
             ['fascia', 'fascium'],
             ['status', 'statu'],
             ['campus', 'campu'],
+            ['axis', 'axes'],
         ];
     }
 


### PR DESCRIPTION
Issue: https://github.com/doctrine/inflector/issues/240

[What Is the Plural of Axis?](https://www.splashlearn.com/math-vocabulary/geometry/axis-plural-axes#1-what-is-the-plural-of-axis)