### PR TITLE
Correct singularization of bois

### DIFF
--- a/src/Rules/French/Uninflected.php
+++ b/src/Rules/French/Uninflected.php
@@ -12,6 +12,8 @@ final class Uninflected
     public static function getSingular(): iterable
     {
         yield from self::getDefault();
+
+        yield new Pattern('bois');
     }
 
     /** @return Pattern[] */

--- a/tests/Rules/French/FrenchFunctionalTest.php
+++ b/tests/Rules/French/FrenchFunctionalTest.php
@@ -55,6 +55,7 @@ class FrenchFunctionalTest extends LanguageFunctionalTest
             ['carnaval', 'carnavals'],
             ['festival', 'festivals'],
             ['récital', 'récitals'],
+            ['bois', 'bois'],
         ];
     }
 


### PR DESCRIPTION
Currently, `echo $inflector->singularize('bois');`  returns `boi`.

This pull request changes that to `bois`.