### PR TITLE
Correct singularization of mas

### DIFF
--- a/src/Rules/French/Uninflected.php
+++ b/src/Rules/French/Uninflected.php
@@ -14,6 +14,7 @@ final class Uninflected
         yield from self::getDefault();
 
         yield new Pattern('bois');
+        yield new Pattern('mas');
     }
 
     /** @return Pattern[] */

--- a/tests/Rules/French/FrenchFunctionalTest.php
+++ b/tests/Rules/French/FrenchFunctionalTest.php
@@ -56,6 +56,7 @@ class FrenchFunctionalTest extends LanguageFunctionalTest
             ['festival', 'festivals'],
             ['récital', 'récitals'],
             ['bois', 'bois'],
+            ['mas', 'mas'],
         ];
     }
 


### PR DESCRIPTION
Currently, 

echo `$inflector->singularize('mas');` returns `ma`.

This pull request changes that to `mas`.