### PR TITLE
Correct singularization of locaux

### DIFF
--- a/src/Rules/French/Inflectible.php
+++ b/src/Rules/French/Inflectible.php
@@ -16,7 +16,7 @@ class Inflectible
     {
         yield new Transformation(new Pattern('/(b|cor|ém|gemm|soupir|trav|vant|vitr)aux$/'), '\1ail');
         yield new Transformation(new Pattern('/ails$/'), 'ail');
-        yield new Transformation(new Pattern('/(journ|chev)aux$/'), '\1al');
+        yield new Transformation(new Pattern('/(journ|chev|loc)aux$/'), '\1al');
         yield new Transformation(new Pattern('/(bijou|caillou|chou|genou|hibou|joujou|pou|au|eu|eau)x$/'), '\1');
         yield new Transformation(new Pattern('/s$/'), '');
     }

--- a/tests/Rules/French/FrenchFunctionalTest.php
+++ b/tests/Rules/French/FrenchFunctionalTest.php
@@ -39,6 +39,7 @@ class FrenchFunctionalTest extends LanguageFunctionalTest
             ['pneu', 'pneus'],
             ['sarrau', 'sarraus'],
             ['journal', 'journaux'],
+            ['local', 'locaux'],
             ['détail', 'détails'],
             ['bail', 'baux'],
             ['corail', 'coraux'],


### PR DESCRIPTION
Currently,

`echo $inflector->singularize('locaux');` returns `locau`.

This pull request changes that to `local`.