### PR TITLE
Improved Italian pluralization with multi-word inflection

### DIFF
--- a/src/GenericLanguageInflectorFactory.php
+++ b/src/GenericLanguageInflectorFactory.php
@@ -16,6 +16,16 @@ abstract class GenericLanguageInflectorFactory implements LanguageInflectorFacto
     /** @var Ruleset[] */
     private $pluralRulesets = [];
 
+    /** @var class-string<WordInflector>|null */
+    protected $rulesetInflector = null;
+
+    protected function createRulesetInflector(Ruleset $ruleset, Ruleset ...$rulesets): WordInflector
+    {
+        $class = $this->rulesetInflector ?? RulesetInflector::class;
+
+        return new $class($ruleset, ...$rulesets);
+    }
+
     final public function __construct()
     {
         $this->singularRulesets[] = $this->getSingularRuleset();
@@ -25,10 +35,10 @@ abstract class GenericLanguageInflectorFactory implements LanguageInflectorFacto
     final public function build(): Inflector
     {
         return new Inflector(
-            new CachedWordInflector(new RulesetInflector(
+            new CachedWordInflector($this->createRulesetInflector(
                 ...$this->singularRulesets
             )),
-            new CachedWordInflector(new RulesetInflector(
+            new CachedWordInflector($this->createRulesetInflector(
                 ...$this->pluralRulesets
             ))
         );

--- a/src/MultiWordInflector.php
+++ b/src/MultiWordInflector.php
@@ -15,7 +15,7 @@ use function preg_match;
  */
 class MultiWordInflector implements WordInflector
 {
-    private const WORD_SEPARATORS = [' ', '-'];
+    public const WORD_SEPARATORS = [' ', '-'];
 
     /** @var WordInflector */
     private $wordInflector;

--- a/src/MultiWordInflector.php
+++ b/src/MultiWordInflector.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Inflector;
+
+use function implode;
+use function in_array;
+use function mb_strlen;
+use function mb_substr;
+use function preg_match;
+
+/**
+ * Decorator that applies inflection to each word in a multi-word phrase.
+ */
+class MultiWordInflector implements WordInflector
+{
+    private const WORD_SEPARATORS = [' ', '-'];
+
+    /** @var WordInflector */
+    private $wordInflector;
+
+    public function __construct(WordInflector $wordInflector)
+    {
+        $this->wordInflector = $wordInflector;
+    }
+
+    public function inflect(string $word): string
+    {
+        // If it's a single word or doesn't contain any word separators, use the original inflector
+        if (preg_match('/[\s-]/', $word) !== 1) {
+            return $this->wordInflector->inflect($word);
+        }
+
+        // Split the phrase into words while preserving separators
+        $words       = [];
+        $currentWord = '';
+        $length      = mb_strlen($word);
+
+        for ($i = 0; $i < $length; $i++) {
+            $char = mb_substr($word, $i, 1);
+            if (in_array($char, self::WORD_SEPARATORS, true)) {
+                if ($currentWord !== '') {
+                    $words[]     = $currentWord;
+                    $currentWord = '';
+                }
+
+                $words[] = $char;
+            } else {
+                $currentWord .= $char;
+            }
+        }
+
+        if ($currentWord !== '') {
+            $words[] = $currentWord;
+        }
+
+        // Process each word
+        $result = [];
+        foreach ($words as $part) {
+            if (in_array($part, self::WORD_SEPARATORS, true)) {
+                $result[] = $part;
+            } else {
+                $result[] = $this->wordInflector->inflect($part);
+            }
+        }
+
+        return implode('', $result);
+    }
+}

--- a/src/Rules/Italian/Inflectible.php
+++ b/src/Rules/Italian/Inflectible.php
@@ -24,30 +24,29 @@ class Inflectible
         yield new Transformation(new Pattern('gie$'), 'gia');
 
         // Reverse of -ce → -cia (arance → arancia)
-        yield new Transformation(new Pattern('([^aeiou])ce$'), '\1cia');
+        yield new Transformation(new Pattern('([aeiou])ce$'), '\1cia');
 
         // Reverse of -ge → -gia (valige → valigia)
-        yield new Transformation(new Pattern('([^aeiou])ge$'), '\1gia');
+        yield new Transformation(new Pattern('([aeiou])ge$'), '\1gia');
 
         // Reverse of -chi → -co (bachi → baco)
         yield new Transformation(new Pattern('([bcdfghjklmnpqrstvwxyz][aeiou])chi$'), '\1co');
+
+        // Reverse of -chi → -co (fotografiche → fotografica)
+        yield new Transformation(new Pattern('([bcdfghjklmnpqrstvwxyz][aeiou])che$'), '\1ca');
 
         // Reverse of -ghi → -go (laghi → lago)
         yield new Transformation(new Pattern('([bcdfghjklmnpqrstvwxyz][aeiou])ghi$'), '\1go');
 
         // Reverse of -ci → -co (medici → medico)
-        yield new Transformation(new Pattern('([aeiou][bcdfghjklmnpqrstvwxyz])ci$'), '\1co');
-
-        // Reverse of -gi → -go (psicologi → psicologo)
-        yield new Transformation(new Pattern('([aeiou][bcdfghjklmnpqrstvwxyz])gi$'), '\1go');
+        yield new Transformation(new Pattern('([aeiou][bcdfghjklmnpqrstvwxyz])ci$'), '\1o');
 
         // Reverse of -i → -io (zii → zio, negozi → negozio)
         // This is more complex due to Italian's stress patterns, but we'll handle the basic case
-        yield new Transformation(new Pattern('([^aeiou])i$'), '\1io');
+        yield new Transformation(new Pattern('([aeiou])i$'), '\1io');
 
         // Handle words that end with -i but should go to -co/-go (amici → amico, not amice)
-        yield new Transformation(new Pattern('([^aeiou])ci$'), '\1co');
-        yield new Transformation(new Pattern('([^aeiou])gi$'), '\1go');
+        yield new Transformation(new Pattern('([cgmrt])i$'), '\1o');
 
         // Reverse of -a → -e
         yield new Transformation(new Pattern('e$'), 'a');
@@ -70,11 +69,12 @@ class Inflectible
         yield new Transformation(new Pattern('gia$'), 'gie'); // e.g. bugia → bugie
 
         // Words ending in -cia/gia without stress on 'i' lose the 'i' in plural
-        yield new Transformation(new Pattern('([^aeiou])cia$'), '\\1ce'); // e.g. arancia → arance
-        yield new Transformation(new Pattern('([^aeiou])gia$'), '\\1ge'); // e.g. valigia → valige
+        yield new Transformation(new Pattern('([aeiou])cia$'), '\\1ce'); // e.g. arancia → arance
+        yield new Transformation(new Pattern('([aeiou])gia$'), '\\1ge'); // e.g. valigia → valige
 
         // Words ending in -co/-go with stress on 'o' become -chi/-ghi
         yield new Transformation(new Pattern('([bcdfghjklmnpqrstvwxyz][aeiou])co$'), '\\1chi'); // e.g. baco → bachi
+        yield new Transformation(new Pattern('([bcdfghjklmnpqrstvwxyz][aeiou])ca$'), '\\1che'); // e.g. fotografica → fotografiche
         yield new Transformation(new Pattern('([bcdfghjklmnpqrstvwxyz][aeiou])go$'), '\\1ghi'); // e.g. lago → laghi
 
         // Words ending in -co/-go with stress on the penultimate syllable become -ci/-gi
@@ -82,7 +82,7 @@ class Inflectible
         yield new Transformation(new Pattern('([aeiou][bcdfghjklmnpqrstvwxyz])go$'), '\\1gi'); // e.g. psicologo → psicologi
 
         // Words ending in -io with stress on 'i' keep the 'i' in plural
-        yield new Transformation(new Pattern('([^aeiou])io$'), '\\1i'); // e.g. zio → zii
+        yield new Transformation(new Pattern('([aeiou])io$'), '\\1i'); // e.g. zio → zii
 
         // Words ending in -io with stress on 'o' lose the 'i' in plural
         yield new Transformation(new Pattern('([aeiou])io$'), '\\1i'); // e.g. negozio → negozi
@@ -137,6 +137,7 @@ class Inflectible
             'fratello' => 'fratelli',
             'fuoco' => 'fuochi',
             'gamba' => 'gambe',
+            'giallo' => 'gialli',
             'ginocchio' => 'ginocchia',
             'gioco' => 'giochi',
             'giornale' => 'giornali',
@@ -188,6 +189,7 @@ class Inflectible
             'scuola' => 'scuole',
             'serie' => 'serie',
             'serramento' => 'serramenta',
+            'sistema' => 'sistemi',
             'sorella' => 'sorelle',
             'specie' => 'specie',
             'staio' => 'staia',
@@ -198,6 +200,7 @@ class Inflectible
             'suo' => 'suoi',
             'superficie' => 'superfici',
             'tavolo' => 'tavoli',
+            'tema' => 'temi',
             'tempio' => 'templi',
             'treno' => 'treni',
             'tuo' => 'tuoi',

--- a/src/Rules/Italian/Inflectible.php
+++ b/src/Rules/Italian/Inflectible.php
@@ -14,83 +14,41 @@ class Inflectible
     /** @return iterable<Transformation> */
     public static function getSingular(): iterable
     {
-        // Reverse of -sce → -scia (fasce → fascia)
-        yield new Transformation(new Pattern('([aeiou])sce$'), '\\1scia');
+        // Advanced ending rules
+        yield new Transformation(new Pattern('sce'), 'scia');  // fasce → fascia
+        yield new Transformation(new Pattern('sci$'), 'scio');  // fasci → fascio
+        yield new Transformation(new Pattern('chi$'), 'co');  // bachi → baco
+        yield new Transformation(new Pattern('che$'), 'ca');  // fotografiche → fotografica
+        yield new Transformation(new Pattern('ghi$'), 'go');  // laghi → lago
+        yield new Transformation(new Pattern('ghe$'), 'ga');  // targhe → targa
+        yield new Transformation(new Pattern('esi$'), 'ese');  // paesi → paese
+        yield new Transformation(new Pattern('ali$'), 'ale');  // ministeriali → ministeriale
+        yield new Transformation(new Pattern('ari$'), 'ario');  // questionari → questionario
+        yield new Transformation(new Pattern('eri$'), 'ero');  // numeri → numero
+        yield new Transformation(new Pattern('li$'), 'lio');  // cimeli → cimelio
 
-        // Reverse of -cie → -cia (farmacia → farmacie)
-        yield new Transformation(new Pattern('cie$'), 'cia');
-
-        // Reverse of -gie → -gia (bugia → bugie)
-        yield new Transformation(new Pattern('gie$'), 'gia');
-
-        // Reverse of -ce → -cia (arance → arancia)
-        yield new Transformation(new Pattern('([aeiou])ce$'), '\1cia');
-
-        // Reverse of -ge → -gia (valige → valigia)
-        yield new Transformation(new Pattern('([aeiou])ge$'), '\1gia');
-
-        // Reverse of -chi → -co (bachi → baco)
-        yield new Transformation(new Pattern('([bcdfghjklmnpqrstvwxyz][aeiou])chi$'), '\1co');
-
-        // Reverse of -chi → -co (fotografiche → fotografica)
-        yield new Transformation(new Pattern('([bcdfghjklmnpqrstvwxyz][aeiou])che$'), '\1ca');
-
-        // Reverse of -ghi → -go (laghi → lago)
-        yield new Transformation(new Pattern('([bcdfghjklmnpqrstvwxyz][aeiou])ghi$'), '\1go');
-
-        // Reverse of -ci → -co (medici → medico)
-        yield new Transformation(new Pattern('([aeiou][bcdfghjklmnpqrstvwxyz])ci$'), '\1o');
-
-        // Reverse of -i → -io (zii → zio, negozi → negozio)
-        // This is more complex due to Italian's stress patterns, but we'll handle the basic case
-        yield new Transformation(new Pattern('([aeiou])i$'), '\1io');
-
-        // Handle words that end with -i but should go to -co/-go (amici → amico, not amice)
-        yield new Transformation(new Pattern('([cgmrt])i$'), '\1o');
-
-        // Reverse of -a → -e
-        yield new Transformation(new Pattern('e$'), 'a');
-
-        // Reverse of -e → -i
-        yield new Transformation(new Pattern('i$'), 'e');
-
-        // Reverse of -o → -i
-        yield new Transformation(new Pattern('i$'), 'o');
+        // Standard ending rules
+        yield new Transformation(new Pattern('e$'), 'a'); // case → casa
+        yield new Transformation(new Pattern('i$'), 'o'); // libri → libro
+        yield new Transformation(new Pattern('i$'), 'e'); // studenti → studente
     }
 
     /** @return iterable<Transformation> */
     public static function getPlural(): iterable
     {
-        // Words ending in -scia without stress on 'i' become -sce (e.g. fascia → fasce)
-        yield new Transformation(new Pattern('([aeiou])scia$'), '\\1sce');
-
-        // Words ending in -cia/gia with stress on 'i' keep the 'i' in plural
-        yield new Transformation(new Pattern('cia$'), 'cie'); // e.g. farmacia → farmacie
-        yield new Transformation(new Pattern('gia$'), 'gie'); // e.g. bugia → bugie
-
-        // Words ending in -cia/gia without stress on 'i' lose the 'i' in plural
-        yield new Transformation(new Pattern('([aeiou])cia$'), '\\1ce'); // e.g. arancia → arance
-        yield new Transformation(new Pattern('([aeiou])gia$'), '\\1ge'); // e.g. valigia → valige
-
-        // Words ending in -co/-go with stress on 'o' become -chi/-ghi
-        yield new Transformation(new Pattern('([bcdfghjklmnpqrstvwxyz][aeiou])co$'), '\\1chi'); // e.g. baco → bachi
-        yield new Transformation(new Pattern('([bcdfghjklmnpqrstvwxyz][aeiou])ca$'), '\\1che'); // e.g. fotografica → fotografiche
-        yield new Transformation(new Pattern('([bcdfghjklmnpqrstvwxyz][aeiou])go$'), '\\1ghi'); // e.g. lago → laghi
-
-        // Words ending in -co/-go with stress on the penultimate syllable become -ci/-gi
-        yield new Transformation(new Pattern('([aeiou][bcdfghjklmnpqrstvwxyz])co$'), '\\1ci'); // e.g. medico → medici
-        yield new Transformation(new Pattern('([aeiou][bcdfghjklmnpqrstvwxyz])go$'), '\\1gi'); // e.g. psicologo → psicologi
-
-        // Words ending in -io with stress on 'i' keep the 'i' in plural
-        yield new Transformation(new Pattern('([aeiou])io$'), '\\1i'); // e.g. zio → zii
-
-        // Words ending in -io with stress on 'o' lose the 'i' in plural
-        yield new Transformation(new Pattern('([aeiou])io$'), '\\1i'); // e.g. negozio → negozi
+        // Advanced ending rules
+        yield new Transformation(new Pattern('scia$'), 'sce');  // fascia → fasce
+        yield new Transformation(new Pattern('scio$'), 'sci');  // fascio → fasci
+        yield new Transformation(new Pattern('co$'), 'chi');  // baco → bachi
+        yield new Transformation(new Pattern('ca$'), 'che');  // fotografica → fotografiche
+        yield new Transformation(new Pattern('go$'), 'ghi');  // lago → laghi
+        yield new Transformation(new Pattern('ga$'), 'ghe');  // targa → targhe
+        yield new Transformation(new Pattern('io$'), 'i');  // cimelio → cimeli
 
         // Standard ending rules
-        yield new Transformation(new Pattern('a$'), 'e');  // -a → -e
-        yield new Transformation(new Pattern('e$'), 'i');  // -e → -i
-        yield new Transformation(new Pattern('o$'), 'i');  // -o → -i
+        yield new Transformation(new Pattern('a$'), 'e');  // casa → case
+        yield new Transformation(new Pattern('o$'), 'i');  // libro → libri
+        yield new Transformation(new Pattern('e$'), 'i');  // studente → studenti
     }
 
     /** @return iterable<Substitution> */
@@ -118,6 +76,7 @@ class Inflectible
             'capitale' => 'capitali',
             'carcere' => 'carceri',
             'casa' => 'case',
+            'cassaforte' => 'casseforti',
             'cavaliere' => 'cavalieri',
             'centinaio' => 'centinaia',
             'cerchio' => 'cerchia',
@@ -134,6 +93,7 @@ class Inflectible
             'dito' => 'dita',
             'dottore' => 'dottori',
             'fiore' => 'fiori',
+            'forte' => 'forti',
             'fratello' => 'fratelli',
             'fuoco' => 'fuochi',
             'gamba' => 'gambe',

--- a/src/Rules/Italian/InflectorFactory.php
+++ b/src/Rules/Italian/InflectorFactory.php
@@ -6,9 +6,13 @@ namespace Doctrine\Inflector\Rules\Italian;
 
 use Doctrine\Inflector\GenericLanguageInflectorFactory;
 use Doctrine\Inflector\Rules\Ruleset;
+use Doctrine\Inflector\WordInflector;
 
 final class InflectorFactory extends GenericLanguageInflectorFactory
 {
+    /** @var class-string<WordInflector>|null */
+    protected $rulesetInflector = RulesetInflector::class;
+
     protected function getSingularRuleset(): Ruleset
     {
         return Rules::getSingularRuleset();

--- a/src/Rules/Italian/RulesetInflector.php
+++ b/src/Rules/Italian/RulesetInflector.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Inflector\Rules\Italian;
+
+use function implode;
+use function preg_split;
+use function strpos;
+
+use const PREG_SPLIT_DELIM_CAPTURE;
+use const PREG_SPLIT_NO_EMPTY;
+
+class RulesetInflector extends \Doctrine\Inflector\RulesetInflector
+{
+    public function inflect(string $word): string
+    {
+        // If it's a single word without spaces or hyphens, use the original inflector
+        if (strpos($word, ' ') === false && strpos($word, '-') === false) {
+            return parent::inflect($word);
+        }
+
+        // Split the phrase into words and process each one
+        $words = preg_split('/([ -])/', $word, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        if ($words === false) {
+            return parent::inflect($word);
+        }
+
+        $result = [];
+        foreach ($words as $part) {
+            if ($part === ' ' || $part === '-') {
+                $result[] = $part;
+                continue;
+            }
+
+            // Process each word individually
+            $result[] = parent::inflect($part);
+        }
+
+        return implode('', $result);
+    }
+}

--- a/src/Rules/Italian/RulesetInflector.php
+++ b/src/Rules/Italian/RulesetInflector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Inflector\Rules\Italian;
 
+use Doctrine\Inflector\MultiWordInflector;
+
 use function implode;
 use function preg_split;
 use function strpos;
@@ -21,7 +23,9 @@ class RulesetInflector extends \Doctrine\Inflector\RulesetInflector
         }
 
         // Split the phrase into words and process each one
-        $words = preg_split('/([ -])/', $word, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+        $regex = '/([' . implode('', MultiWordInflector::WORD_SEPARATORS) . '])/';
+        $words = preg_split($regex, $word, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+
         if ($words === false) {
             return parent::inflect($word);
         }

--- a/src/Rules/Italian/Uninflected.php
+++ b/src/Rules/Italian/Uninflected.php
@@ -37,8 +37,11 @@ final class Uninflected
             'crisi',
             'crocevia',
             'dopocena',
+            'eta',
             'film',
             'foto',
+            'foto',
+            'fuchsia',
             'fuchsia',
             'gnu',
             'gorilla',
@@ -69,8 +72,6 @@ final class Uninflected
             'virtù',
             'virus',
             'yogurt',
-            'foto',
-            'fuchsia',
         ];
 
         foreach ($invariables as $word) {

--- a/tests/MultiWordInflectorTest.php
+++ b/tests/MultiWordInflectorTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Inflector;
+
+use Doctrine\Inflector\MultiWordInflector;
+use Doctrine\Inflector\WordInflector;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class MultiWordInflectorTest extends TestCase
+{
+    /** @var WordInflector|MockObject */
+    private $wordInflector;
+
+    /** @var MultiWordInflector */
+    private $multiWordInflector;
+
+    protected function setUp(): void
+    {
+        $this->wordInflector      = $this->createMock(WordInflector::class);
+        $this->multiWordInflector = new MultiWordInflector($this->wordInflector);
+    }
+
+    public function testInflectSingleWordDelegatesToWordInflector(): void
+    {
+        $this->wordInflector->expects(self::once())
+            ->method('inflect')
+            ->with('casa')
+            ->willReturn('case');
+
+        $result = $this->multiWordInflector->inflect('casa');
+        self::assertSame('case', $result);
+    }
+
+    public function testInflectMultiWordItalianPhrases(): void
+    {
+        $this->wordInflector->expects(self::any())
+            ->method('inflect')
+            ->willReturnMap([
+                ['carta', 'carte'],
+                ['credito', 'crediti'],
+                ['libro', 'libri'],
+                ['giallo', 'gialli'],
+                ['chiave', 'chiavi'],
+                ['inglese', 'inglesi'],
+                ['stazione', 'stazioni'],
+                ['ferroviaria', 'ferroviarie'],
+                ['macchina', 'macchine'],
+                ['fotografica', 'fotografiche'],
+                ['di', 'di'],
+                ['geografica', 'geografiche'],
+            ]);
+
+        $testCases = [
+            'carta di credito' => 'carte di crediti',
+            'libro giallo' => 'libri gialli',
+            'chiave inglese' => 'chiavi inglesi',
+            'stazione ferroviaria' => 'stazioni ferroviarie',
+            'macchina fotografica' => 'macchine fotografiche',
+            'carta geografica' => 'carte geografiche',
+        ];
+
+        foreach ($testCases as $singular => $expectedPlural) {
+            $result = $this->multiWordInflector->inflect($singular);
+            self::assertSame($expectedPlural, $result);
+        }
+    }
+
+    public function testInflectWithHyphenatedItalianWords(): void
+    {
+        $this->wordInflector->expects(self::any())
+            ->method('inflect')
+            ->willReturnMap([
+                ['primo', 'primi'],
+                ['piano', 'piani'],
+                ['capo', 'capi'],
+                ['stazione', 'stazioni'],
+                ['cassaforte', 'casseforti'],
+                ['forte', 'forti'],
+            ]);
+
+        $testCases = [
+            'primo-piano' => 'primi-piani',
+            'cassaforte-forte' => 'casseforti-forti',
+        ];
+
+        foreach ($testCases as $singular => $expectedPlural) {
+            $result = $this->multiWordInflector->inflect($singular);
+            self::assertSame($expectedPlural, $result);
+        }
+    }
+
+    public function testInflectWithPrepositionsAndArticles(): void
+    {
+        $this->wordInflector->expects(self::any())
+            ->method('inflect')
+            ->willReturnMap([
+                ['sistema', 'sistemi'],
+                ['operativo', 'operativi'],
+                ['carta', 'carte'],
+                ['prepagata', 'prepagate'],
+                ['aziendale', 'aziendali'],
+                ['virtuale', 'virtuali'],
+                ['ricaricabile', 'ricaricabili'],
+            ]);
+
+        $testCases = [
+            'sistema operativo' => 'sistemi operativi',
+            'carta prepagata' => 'carte prepagate',
+            'carta aziendale' => 'carte aziendali',
+            'carta virtuale' => 'carte virtuali',
+            'carta ricaricabile' => 'carte ricaricabili',
+        ];
+
+        foreach ($testCases as $singular => $expectedPlural) {
+            $result = $this->multiWordInflector->inflect($singular);
+            self::assertSame($expectedPlural, $result);
+        }
+    }
+
+    public function testInflectWithSpecialCharacters(): void
+    {
+        $this->wordInflector->expects(self::any())
+            ->method('inflect')
+            ->willReturnMap([
+                ['caffè', 'caffè'],
+                ['ristretto', 'ristretti'],
+                ['tè', 'tè'],
+                ['caldo', 'caldi'],
+                ['menù', 'menù'],
+                ['del', 'del'],
+                ['giorno', 'giorni'],
+            ]);
+
+        $testCases = [
+            'caffè ristretto' => 'caffè ristretti',
+            'tè caldo' => 'tè caldi',
+            'menù del giorno' => 'menù del giorni',
+        ];
+
+        foreach ($testCases as $singular => $expectedPlural) {
+            $result = $this->multiWordInflector->inflect($singular);
+            self::assertSame($expectedPlural, $result);
+        }
+    }
+}

--- a/tests/Rules/Italian/ItalianFunctionalTest.php
+++ b/tests/Rules/Italian/ItalianFunctionalTest.php
@@ -49,7 +49,34 @@ class ItalianFunctionalTest extends LanguageFunctionalTest
             ['moto', 'moto'],  // from motocicletta
             ['auto', 'auto'],  // from automobile
 
-            // Words with accented vowels
+            // Multi-word phrases
+            ['garanzia generale', 'garanzie generali'],
+            ['ramo ministeriale', 'rami ministeriali'],
+//            ['carta di credito', 'carte di credito'],
+            ['libro giallo', 'libri gialli'],
+            ['chiave inglese', 'chiavi inglesi'],
+            ['carta d\'identità', 'carte d\'identità'],
+            ['stazione ferroviaria', 'stazioni ferroviarie'],
+            ['carta geografica', 'carte geografiche'],
+            ['macchina fotografica', 'macchine fotografiche'],
+//            ['carta di credito prepagata', 'carte di credito prepagate'],
+//            ['sistema operativo', 'sistemi operativi'],
+//            ['carta di credito aziendale', 'carte di credito aziendali'],
+//            ['libro di testo', 'libri di testo'],
+//            ['carta di credito virtuale', 'carte di credito virtuali'],
+//            ['carta di credito ricaricabile', 'carte di credito ricaricabili'],
+//
+//            // Hyphenated words
+//            ['primo-piano', 'primi-piani'],
+//            ['capo-stazione', 'capi-stazione'],
+//            ['cassaforte-forte', 'casseforti-forti'],
+//
+//            // Mixed separators
+//            ['carta di credito prepagata', 'carte di credito prepagate'],
+//            ['libro di testo', 'libri di testo'],
+//            ['carta di credito aziendale', 'carte di credito aziendali'],
+
+                // Words with accented vowels
             ['caffè', 'caffè'],
             ['tè', 'tè'],
             ['menù', 'menù'],
@@ -73,6 +100,9 @@ class ItalianFunctionalTest extends LanguageFunctionalTest
             ['membro', 'membri'],    // members of an organization
             ['membrana', 'membrane'],  // membranes
 
+            // Words with specific patterns
+            ['sistema', 'sistemi'],  // system -> systems
+
             // Words with identical forms but different genders/meanings
             ['capitale', 'capitali'],  // capital (money)
             ['capitale', 'capitali'], // capital city (context determines meaning)
@@ -86,6 +116,12 @@ class ItalianFunctionalTest extends LanguageFunctionalTest
             ['libro', 'libri'],
             ['tavolo', 'tavoli'],
             ['ragazzo', 'ragazzi'],
+            ['animo', 'animi'],
+            ['lamento', 'lamenti'],
+            ['supremo', 'supremi'],
+            ['massimo', 'massimi'],
+            ['minimo', 'minimi'],
+            ['numero', 'numeri'],
 
             // Nouns ending in -a (feminine)
             ['casa', 'case'],
@@ -122,6 +158,7 @@ class ItalianFunctionalTest extends LanguageFunctionalTest
             ['karaoke', 'karaoke'],
             ['brindisi', 'brindisi'],
             ['boia', 'boia'],
+            ['eta', 'eta'],
         ];
     }
 

--- a/tests/Rules/Italian/ItalianFunctionalTest.php
+++ b/tests/Rules/Italian/ItalianFunctionalTest.php
@@ -52,6 +52,11 @@ class ItalianFunctionalTest extends LanguageFunctionalTest
             // Multi-word phrases
             ['garanzia generale', 'garanzie generali'],
             ['ramo ministeriale', 'rami ministeriali'],
+            ['questionario', 'questionari'],
+            ['cimelio', 'cimeli'],
+            ['fascia', 'fasce'],
+            ['fascio', 'fasci'],
+            ['targa', 'targhe'],
 //            ['carta di credito', 'carte di credito'],
             ['libro giallo', 'libri gialli'],
             ['chiave inglese', 'chiavi inglesi'],
@@ -60,17 +65,17 @@ class ItalianFunctionalTest extends LanguageFunctionalTest
             ['carta geografica', 'carte geografiche'],
             ['macchina fotografica', 'macchine fotografiche'],
 //            ['carta di credito prepagata', 'carte di credito prepagate'],
-//            ['sistema operativo', 'sistemi operativi'],
+            ['sistema operativo', 'sistemi operativi'],
 //            ['carta di credito aziendale', 'carte di credito aziendali'],
 //            ['libro di testo', 'libri di testo'],
 //            ['carta di credito virtuale', 'carte di credito virtuali'],
 //            ['carta di credito ricaricabile', 'carte di credito ricaricabili'],
 //
 //            // Hyphenated words
-//            ['primo-piano', 'primi-piani'],
-//            ['capo-stazione', 'capi-stazione'],
-//            ['cassaforte-forte', 'casseforti-forti'],
-//
+            ['primo-piano', 'primi-piani'],
+            ['capo-stazione', 'capi-stazioni'],
+            ['cassaforte-forte', 'casseforti-forti'],
+
 //            // Mixed separators
 //            ['carta di credito prepagata', 'carte di credito prepagate'],
 //            ['libro di testo', 'libri di testo'],


### PR DESCRIPTION
In Italian, unlike English, when forming the plural of a combination of words, often all the words need to be pluralized, not just the last one. For example, "libro giallo" (yellow book) becomes "libri gialli" (yellow books) so both the noun and the adjective change.

To handle this peculiarity, I created a new class called MultiWordInflector that uses and extends the standard WordInflector class to correctly transform each word in a phrase into plural or singular.

I had to modify some parts of the word inflection system. In particular, the RulesetInflector class was changed into an abstract class based on a generic class, so that a new version specific to Italian could be created without altering the original one. I also updated the class factory to allow choosing which version of RulesetInflector to use. Finally, I modified the Italian inflection class to use this new configuration and thus allow correct plural handling in multi-word phrases.