### PR TITLE
Use the proper operator

### DIFF
--- a/tests/CachedWordInflectorTest.php
+++ b/tests/CachedWordInflectorTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 class CachedWordInflectorTest extends TestCase
 {
-    /** @var WordInflector|MockObject */
+    /** @var WordInflector&MockObject */
     private $wordInflector;
 
     /** @var CachedWordInflector */

--- a/tests/InflectorTest.php
+++ b/tests/InflectorTest.php
@@ -12,10 +12,10 @@ use PHPUnit\Framework\TestCase;
 
 class InflectorTest extends TestCase
 {
-    /** @var WordInflector|MockObject */
+    /** @var WordInflector&MockObject */
     private $singularInflector;
 
-    /** @var WordInflector|MockObject */
+    /** @var WordInflector&MockObject */
     private $pluralInflector;
 
     /** @var Inflector */


### PR DESCRIPTION
Spotted while converting the codebase to PHP 8.4. Static analysis is OK with this when it is in a phpdoc comment, but not as a property.

Using a pipe to mean "and" is a legacy of a time where & was not understood by tooling.