### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -5,24 +5,24 @@
     "docsSlug": "doctrine-inflector",
     "versions": [
         {
-            "name": "2.1",
-            "branchName": "2.1.x",
-            "slug": "2.1",
+            "name": "2.2",
+            "branchName": "2.2.x",
+            "slug": "2.2",
             "upcoming": true
         },
         {
+            "name": "2.1",
+            "branchName": "2.1.x",
+            "slug": "2.1",
+            "current": true
+        },
+        {
             "name": "2.0",
-            "branchName": "2.0.x",
             "slug": "2.0",
-            "current": true,
-            "aliases": [
-                "current",
-                "stable"
-            ]
+            "maintained": false
         },
         {
             "name": "1.4",
-            "branchName": "1.4.x",
             "slug": "1.4",
             "maintained": false
         },


### PR DESCRIPTION
- 2.2.x is the new minor branch
- 2.1.x is the new patch branch
- 2.0.x is no longer maintained
- some branches no longer exist and should not have a branch name
- the aliases are not needed when "current" is true.