### PR TITLE
Support pluralization for acronyms with edge case coverage

### DIFF
--- a/src/Rules/English/Inflectible.php
+++ b/src/Rules/English/Inflectible.php
@@ -84,7 +84,7 @@ class Inflectible
         yield new Transformation(new Pattern('us$'), 'uses');
         yield new Transformation(new Pattern('(alias)$'), '\1es');
         yield new Transformation(new Pattern('(analys|ax|cris|test|thes)is$'), '\1es');
-        yield new Transformation(new Pattern('s$'), 's');
+        yield new Transformation(new Pattern('(?-i:s$)'), 's');
         yield new Transformation(new Pattern('^$'), '');
         yield new Transformation(new Pattern('$'), 's');
     }

--- a/src/Rules/English/Uninflected.php
+++ b/src/Rules/English/Uninflected.php
@@ -160,6 +160,8 @@ final class Uninflected
         yield new Pattern('siemens');
         yield new Pattern('silk');
         yield new Pattern('sms');
+        yield new Pattern('gps');
+        yield new Pattern('ups');
         yield new Pattern('soap');
         yield new Pattern('social media');
         yield new Pattern('spam');

--- a/tests/Rules/English/EnglishFunctionalTest.php
+++ b/tests/Rules/English/EnglishFunctionalTest.php
@@ -375,6 +375,65 @@ class EnglishFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    /** @return string[][] */
+    public static function dataAcronymWords(): array
+    {
+        return [
+            ['CD', 'CDs'],
+            ['DVD', 'DVDs'],
+            ['NLP', 'NLPs'],
+            ['LMS', 'LMSs'],
+            ['CMS', 'CMSs'],
+            ['DNS', 'DNSs'],
+        ];
+    }
+
+    /** @dataProvider dataAcronymWords */
+    #[DataProvider('dataAcronymWords')]
+    public function testAcronymWords(string $singular, string $plural): void
+    {
+        $inflector = $this->createInflector();
+
+        self::assertSame(
+            $plural,
+            $inflector->pluralize($singular),
+            sprintf("'%s' should be pluralized to '%s'", $singular, $plural)
+        );
+    }
+
+    /** @return string[][] */
+    public static function dataAcronymEdgeCases(): array
+    {
+        return [
+            ['A', 'As'],
+            ['UPS', 'UPS'],
+            ['GPS', 'GPS'],
+            ['SMS', 'SMS'],
+            ['U.S.', 'U.S.s'],
+            ['U-S', 'U-Ss'],
+            ['APIKey', 'APIKeys'],
+            ['CDPlayer', 'CDPlayers'],
+            ['SMS', 'SMS'],
+            ['NEWS', 'NEWS'],
+            ['US', 'US'],
+            ['cms', 'cms'],
+        ];
+    }
+
+    /** @dataProvider dataAcronymEdgeCases */
+    #[DataProvider('dataAcronymEdgeCases')]
+    public function testAcronymEdgeCases(string $singular, string $plural): void
+    {
+        $inflector = $this->createInflector();
+
+        self::assertSame(
+            $plural,
+            $inflector->pluralize($singular),
+            sprintf("'%s' should be pluralized to '%s'", $singular, $plural)
+        );
+    }
+
+
     /**
      * Singulars as Plural test data.
      *


### PR DESCRIPTION
There was an issue with pluralizing some acronyms (such as LMS, CMS, DNS) that were incorrectly transformed.
This has been fixed with minimal changes and without introducing side effects.
Additional tests were added to cover these cases and related edge cases.

Investigating the problem reported in https://github.com/laravel/framework/issues/56932 led to discovering this issue in this package and creating this merge request.