### PR TITLE
Added swedish language support

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -44,6 +44,7 @@ The supported languages are as follows:
 - ``Language::NORWEGIAN_BOKMAL``
 - ``Language::PORTUGUESE``
 - ``Language::SPANISH``
+- ``Language::SWEDISH``
 - ``Language::TURKISH``
 
 If you want to manually construct the inflector instead of using a factory, you can do so like this:

--- a/src/InflectorFactory.php
+++ b/src/InflectorFactory.php
@@ -11,6 +11,7 @@ use Doctrine\Inflector\Rules\Italian;
 use Doctrine\Inflector\Rules\NorwegianBokmal;
 use Doctrine\Inflector\Rules\Portuguese;
 use Doctrine\Inflector\Rules\Spanish;
+use Doctrine\Inflector\Rules\Swedish;
 use Doctrine\Inflector\Rules\Turkish;
 use InvalidArgumentException;
 
@@ -46,6 +47,9 @@ final class InflectorFactory
 
             case Language::SPANISH:
                 return new Spanish\InflectorFactory();
+
+            case Language::SWEDISH:
+                return new Swedish\InflectorFactory();
 
             case Language::TURKISH:
                 return new Turkish\InflectorFactory();

--- a/src/Language.php
+++ b/src/Language.php
@@ -13,6 +13,7 @@ final class Language
     public const NORWEGIAN_BOKMAL = 'norwegian-bokmal';
     public const PORTUGUESE       = 'portuguese';
     public const SPANISH          = 'spanish';
+    public const SWEDISH          = 'swedish';
     public const TURKISH          = 'turkish';
 
     private function __construct()

--- a/src/Rules/Swedish/Inflectible.php
+++ b/src/Rules/Swedish/Inflectible.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Inflector\Rules\Swedish;
+
+use Doctrine\Inflector\Rules\Pattern;
+use Doctrine\Inflector\Rules\Substitution;
+use Doctrine\Inflector\Rules\Transformation;
+use Doctrine\Inflector\Rules\Word;
+
+class Inflectible
+{
+    /** @return Transformation[] */
+    public static function getSingular(): iterable
+    {
+        yield new Transformation(new Pattern('/eringar$/i'), 'ering');
+        yield new Transformation(new Pattern('/ioner$/i'), 'ion');
+        yield new Transformation(new Pattern('/eer$/i'), 'eum');
+        yield new Transformation(new Pattern('/örer$/i'), 'ör');
+        yield new Transformation(new Pattern('/ärer$/i'), 'är');
+        yield new Transformation(new Pattern('/erier$/i'), 'erie');
+        yield new Transformation(new Pattern('/dier$/i'), 'die');
+        yield new Transformation(new Pattern('/orer$/i'), 'or');
+        yield new Transformation(new Pattern('/ier$/i'), 'i');
+        yield new Transformation(new Pattern('/jer$/i'), 'j');
+        yield new Transformation(new Pattern('/nar$/i'), 'en');
+        yield new Transformation(new Pattern('/kar$/i'), 'ke');
+        yield new Transformation(new Pattern('/kor$/i'), 'ka');
+        yield new Transformation(new Pattern('/mar$/i'), 'me');
+        yield new Transformation(new Pattern('/nar$/i'), 'n');
+        yield new Transformation(new Pattern('/nor$/i'), 'na');
+        yield new Transformation(new Pattern('/rar$/i'), 'er');
+        yield new Transformation(new Pattern('/sor$/i'), 'sa');
+        yield new Transformation(new Pattern('/tor$/i'), 'ta');
+        yield new Transformation(new Pattern('/der$/i'), 'd');
+        yield new Transformation(new Pattern('/ter$/i'), 't');
+        yield new Transformation(new Pattern('/or$/i'), 'a');
+        yield new Transformation(new Pattern('/ar$/i'), '');
+        yield new Transformation(new Pattern('/er$/i'), '');
+    }
+
+    /** @return Transformation[] */
+    public static function getPlural(): iterable
+    {
+        yield new Transformation(new Pattern('/ering$/i'), 'eringar');
+        yield new Transformation(new Pattern('/ion$/i'), 'ioner');
+        yield new Transformation(new Pattern('/ör$/i'), 'örer');
+        yield new Transformation(new Pattern('/är$/i'), 'ärer');
+        yield new Transformation(new Pattern('/or$/i'), 'orer');
+        yield new Transformation(new Pattern('/i$/i'), 'ier');
+        yield new Transformation(new Pattern('/j$/i'), 'jer');
+        yield new Transformation(new Pattern('/um$/i'), 'er');
+        yield new Transformation(new Pattern('/en$/i'), 'nar');
+        yield new Transformation(new Pattern('/er$/i'), 'rar');
+        yield new Transformation(new Pattern('/ie$/i'), 'ier');
+        yield new Transformation(new Pattern('/ka$/i'), 'kor');
+        yield new Transformation(new Pattern('/na$/i'), 'nor');
+        yield new Transformation(new Pattern('/sa$/i'), 'sor');
+        yield new Transformation(new Pattern('/ta$/i'), 'tor');
+        yield new Transformation(new Pattern('/a$/i'), 'or');
+        yield new Transformation(new Pattern('/t$/i'), 'ter');
+        yield new Transformation(new Pattern('/d$/i'), 'der');
+        yield new Transformation(new Pattern('/e$/i'), 'ar');
+        yield new Transformation(new Pattern('/([bfghjklmnpqrstvwxyz])$/i'), '\1ar');
+        yield new Transformation(new Pattern('/$/'), 'er');
+    }
+
+    /** @return Substitution[] */
+    public static function getIrregular(): iterable
+    {
+        yield new Substitution(new Word('and'), new Word('änder'));
+        yield new Substitution(new Word('bok'), new Word('böcker'));
+        yield new Substitution(new Word('bonde'), new Word('bönder'));
+        yield new Substitution(new Word('brand'), new Word('bränder'));
+        yield new Substitution(new Word('bror'), new Word('bröder'));
+        yield new Substitution(new Word('cykel'), new Word('cyklar'));
+        yield new Substitution(new Word('dotter'), new Word('döttrar'));
+        yield new Substitution(new Word('dräkt'), new Word('dräkter'));
+        yield new Substitution(new Word('fader'), new Word('fäder'));
+        yield new Substitution(new Word('far'), new Word('fäder'));
+        yield new Substitution(new Word('fjäder'), new Word('fjädrar'));
+        yield new Substitution(new Word('fot'), new Word('fötter'));
+        yield new Substitution(new Word('get'), new Word('getter'));
+        yield new Substitution(new Word('gås'), new Word('gäss'));
+        yield new Substitution(new Word('hand'), new Word('händer'));
+        yield new Substitution(new Word('huvud'), new Word('huvuden'));
+        yield new Substitution(new Word('ko'), new Word('kor'));
+        yield new Substitution(new Word('land'), new Word('länder'));
+        yield new Substitution(new Word('ledamot'), new Word('ledamöter'));
+        yield new Substitution(new Word('lem'), new Word('lemmar'));
+        yield new Substitution(new Word('lus'), new Word('löss'));
+        yield new Substitution(new Word('man'), new Word('män'));
+        yield new Substitution(new Word('moder'), new Word('mödrar'));
+        yield new Substitution(new Word('mor'), new Word('mödrar'));
+        yield new Substitution(new Word('mus'), new Word('möss'));
+        yield new Substitution(new Word('månad'), new Word('månader'));
+        yield new Substitution(new Word('natt'), new Word('nätter'));
+        yield new Substitution(new Word('rand'), new Word('ränder'));
+        yield new Substitution(new Word('rot'), new Word('rötter'));
+        yield new Substitution(new Word('skrift'), new Word('skrifter'));
+        yield new Substitution(new Word('son'), new Word('söner'));
+        yield new Substitution(new Word('stad'), new Word('städer'));
+        yield new Substitution(new Word('strand'), new Word('stränder'));
+        yield new Substitution(new Word('syster'), new Word('systrar'));
+        yield new Substitution(new Word('tand'), new Word('tänder'));
+        yield new Substitution(new Word('trad'), new Word('trådar'));
+        yield new Substitution(new Word('trakt'), new Word('trakter'));
+        yield new Substitution(new Word('tå'), new Word('tår'));
+        yield new Substitution(new Word('vinter'), new Word('vintrar'));
+        yield new Substitution(new Word('vy'), new Word('vyer'));
+        yield new Substitution(new Word('vän'), new Word('vänner'));
+        yield new Substitution(new Word('äpple'), new Word('äpplen'));
+        yield new Substitution(new Word('ö'), new Word('öar'));
+        yield new Substitution(new Word('öde'), new Word('öden'));
+        yield new Substitution(new Word('öga'), new Word('ögon'));
+        yield new Substitution(new Word('ört'), new Word('örter'));
+        yield new Substitution(new Word('öra'), new Word('öron'));
+        yield new Substitution(new Word('öre'), new Word('ören'));
+    }
+}

--- a/src/Rules/Swedish/InflectorFactory.php
+++ b/src/Rules/Swedish/InflectorFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Inflector\Rules\Swedish;
+
+use Doctrine\Inflector\GenericLanguageInflectorFactory;
+use Doctrine\Inflector\Rules\Ruleset;
+
+final class InflectorFactory extends GenericLanguageInflectorFactory
+{
+    protected function getSingularRuleset(): Ruleset
+    {
+        return Rules::getSingularRuleset();
+    }
+
+    protected function getPluralRuleset(): Ruleset
+    {
+        return Rules::getPluralRuleset();
+    }
+}

--- a/src/Rules/Swedish/Rules.php
+++ b/src/Rules/Swedish/Rules.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Inflector\Rules\Swedish;
+
+use Doctrine\Inflector\Rules\Patterns;
+use Doctrine\Inflector\Rules\Ruleset;
+use Doctrine\Inflector\Rules\Substitutions;
+use Doctrine\Inflector\Rules\Transformations;
+
+final class Rules
+{
+    public static function getSingularRuleset(): Ruleset
+    {
+        return new Ruleset(
+            new Transformations(...Inflectible::getSingular()),
+            new Patterns(...Uninflected::getSingular()),
+            (new Substitutions(...Inflectible::getIrregular()))->getFlippedSubstitutions()
+        );
+    }
+
+    public static function getPluralRuleset(): Ruleset
+    {
+        return new Ruleset(
+            new Transformations(...Inflectible::getPlural()),
+            new Patterns(...Uninflected::getPlural()),
+            new Substitutions(...Inflectible::getIrregular())
+        );
+    }
+}

--- a/src/Rules/Swedish/Uninflected.php
+++ b/src/Rules/Swedish/Uninflected.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Inflector\Rules\Swedish;
+
+use Doctrine\Inflector\Rules\Pattern;
+
+final class Uninflected
+{
+    /** @return Pattern[] */
+    public static function getSingular(): iterable
+    {
+        yield from self::getDefault();
+    }
+
+    /** @return Pattern[] */
+    public static function getPlural(): iterable
+    {
+        yield from self::getDefault();
+    }
+
+    /** @return Pattern[] */
+    private static function getDefault(): iterable
+    {
+        yield new Pattern('barn');
+        yield new Pattern('bröd');
+        yield new Pattern('djur');
+        yield new Pattern('folk');
+        yield new Pattern('får');
+        yield new Pattern('hus');
+        yield new Pattern('kaffe');
+        yield new Pattern('namn');
+        yield new Pattern('ord');
+        yield new Pattern('rum');
+        yield new Pattern('träd');
+        yield new Pattern('vatten');
+        yield new Pattern('ägg');
+    }
+}

--- a/tests/Rules/Swedish/SwedishFunctionalTest.php
+++ b/tests/Rules/Swedish/SwedishFunctionalTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Inflector\Rules\Swedish;
+
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
+use Doctrine\Inflector\Language;
+use Doctrine\Tests\Inflector\Rules\LanguageFunctionalTestCase;
+
+class SwedishFunctionalTest extends LanguageFunctionalTestCase
+{
+    /** @return string[][] */
+    public static function dataSampleWords(): array
+    {
+        return [
+            ['and', 'änder'],
+            ['barn', 'barn'],
+            ['bil', 'bilar'],
+            ['bok', 'böcker'],
+            ['bror', 'bröder'],
+            ['cykel', 'cyklar'],
+            ['dag', 'dagar'],
+            ['direktör', 'direktörer'],
+            ['djur', 'djur'],
+            ['dotter', 'döttrar'],
+            ['faktor', 'faktorer'],
+            ['faktura', 'fakturor'],
+            ['familj', 'familjer'],
+            ['far', 'fäder'],
+            ['finger', 'fingrar'],
+            ['flicka', 'flickor'],
+            ['folk', 'folk'],
+            ['fot', 'fötter'],
+            ['får', 'får'],
+            ['gata', 'gator'],
+            ['gås', 'gäss'],
+            ['hand', 'händer'],
+            ['hus', 'hus'],
+            ['ingenjör', 'ingenjörer'],
+            ['instruktör', 'instruktörer'],
+            ['kaffe', 'kaffe'],
+            ['kategori', 'kategorier'],
+            ['ko', 'kor'],
+            ['krona', 'kronor'],
+            ['kvinna', 'kvinnor'],
+            ['land', 'länder'],
+            ['lektion', 'lektioner'],
+            ['man', 'män'],
+            ['militär', 'militärer'],
+            ['mor', 'mödrar'],
+            ['motor', 'motorer'],
+            ['museum', 'museer'],
+            ['mus', 'möss'],
+            ['månad', 'månader'],
+            ['namn', 'namn'],
+            ['nota', 'notor'],
+            ['pojke', 'pojkar'],
+            ['privat', 'privater'],
+            ['prinsessa', 'prinsessor'],
+            ['professor', 'professorer'],
+            ['region', 'regioner'],
+            ['regering', 'regeringar'],
+            ['rot', 'rötter'],
+            ['rum', 'rum'],
+            ['sekreterär', 'sekreterärer'],
+            ['serie', 'serier'],
+            ['son', 'söner'],
+            ['stad', 'städer'],
+            ['stol', 'stolar'],
+            ['strand', 'stränder'],
+            ['studie', 'studier'],
+            ['tand', 'tänder'],
+            ['tidning', 'tidningar'],
+            ['timme', 'timmar'],
+            ['träd', 'träd'],
+            ['tå', 'tår'],
+            ['vara', 'varor'],
+            ['vatten', 'vatten'],
+            ['vecka', 'veckor'],
+            ['överraskning', 'överraskningar'],
+            ['öga', 'ögon'],
+            ['öra', 'öron'],
+        ];
+    }
+
+    protected function createInflector(): Inflector
+    {
+        return InflectorFactory::createForLanguage(Language::SWEDISH)->build();
+    }
+}


### PR DESCRIPTION
This pull request adds Swedish language support.

```php
$inflector = InflectorFactory::createForLanguage(Language::SWEDISH)->build();
$inflector->pluralize('flicka');   // flickor
$inflector->pluralize('bil');      // bilar
$inflector->pluralize('man');      // män (irregular)
$inflector->singularize('bilar');  // bil
```

Handles common patterns (a→or, e→ar, consonant+ar), irregular vowel changes (umlaut), and uninflected words.
