### PR TITLE
Run Rector on the codebase

### DIFF
--- a/src/InflectorFactory.php
+++ b/src/InflectorFactory.php
@@ -26,39 +26,20 @@ final readonly class InflectorFactory
 
     public static function createForLanguage(string $language): LanguageInflectorFactory
     {
-        switch ($language) {
-            case Language::ENGLISH:
-                return new English\InflectorFactory();
-
-            case Language::ESPERANTO:
-                return new Esperanto\InflectorFactory();
-
-            case Language::FRENCH:
-                return new French\InflectorFactory();
-
-            case Language::ITALIAN:
-                return new Italian\InflectorFactory();
-
-            case Language::NORWEGIAN_BOKMAL:
-                return new NorwegianBokmal\InflectorFactory();
-
-            case Language::PORTUGUESE:
-                return new Portuguese\InflectorFactory();
-
-            case Language::SPANISH:
-                return new Spanish\InflectorFactory();
-
-            case Language::SWEDISH:
-                return new Swedish\InflectorFactory();
-
-            case Language::TURKISH:
-                return new Turkish\InflectorFactory();
-
-            default:
-                throw new InvalidArgumentException(sprintf(
-                    'Language "%s" is not supported.',
-                    $language,
-                ));
-        }
+        return match ($language) {
+            Language::ENGLISH => new English\InflectorFactory(),
+            Language::ESPERANTO => new Esperanto\InflectorFactory(),
+            Language::FRENCH => new French\InflectorFactory(),
+            Language::ITALIAN => new Italian\InflectorFactory(),
+            Language::NORWEGIAN_BOKMAL => new NorwegianBokmal\InflectorFactory(),
+            Language::PORTUGUESE => new Portuguese\InflectorFactory(),
+            Language::SPANISH => new Spanish\InflectorFactory(),
+            Language::SWEDISH => new Swedish\InflectorFactory(),
+            Language::TURKISH => new Turkish\InflectorFactory(),
+            default => throw new InvalidArgumentException(sprintf(
+                'Language "%s" is not supported.',
+                $language,
+            )),
+        };
     }
 }

--- a/src/Rules/English/Rules.php
+++ b/src/Rules/English/Rules.php
@@ -16,7 +16,7 @@ final class Rules
         return new Ruleset(
             new Transformations(...Inflectible::getSingular()),
             new Patterns(...Uninflected::getSingular()),
-            (new Substitutions(...Inflectible::getIrregular()))->getFlippedSubstitutions(),
+            new Substitutions(...Inflectible::getIrregular())->getFlippedSubstitutions(),
         );
     }
 

--- a/src/Rules/Esperanto/Rules.php
+++ b/src/Rules/Esperanto/Rules.php
@@ -16,7 +16,7 @@ final class Rules
         return new Ruleset(
             new Transformations(...Inflectible::getSingular()),
             new Patterns(...Uninflected::getSingular()),
-            (new Substitutions(...Inflectible::getIrregular()))->getFlippedSubstitutions(),
+            new Substitutions(...Inflectible::getIrregular())->getFlippedSubstitutions(),
         );
     }
 

--- a/src/Rules/French/Rules.php
+++ b/src/Rules/French/Rules.php
@@ -16,7 +16,7 @@ final class Rules
         return new Ruleset(
             new Transformations(...Inflectible::getSingular()),
             new Patterns(...Uninflected::getSingular()),
-            (new Substitutions(...Inflectible::getIrregular()))->getFlippedSubstitutions(),
+            new Substitutions(...Inflectible::getIrregular())->getFlippedSubstitutions(),
         );
     }
 

--- a/src/Rules/Italian/Rules.php
+++ b/src/Rules/Italian/Rules.php
@@ -16,7 +16,7 @@ final class Rules
         return new Ruleset(
             new Transformations(...Inflectible::getSingular()),
             new Patterns(...Uninflected::getSingular()),
-            (new Substitutions(...Inflectible::getIrregular()))->getFlippedSubstitutions(),
+            new Substitutions(...Inflectible::getIrregular())->getFlippedSubstitutions(),
         );
     }
 

--- a/src/Rules/NorwegianBokmal/Rules.php
+++ b/src/Rules/NorwegianBokmal/Rules.php
@@ -16,7 +16,7 @@ final class Rules
         return new Ruleset(
             new Transformations(...Inflectible::getSingular()),
             new Patterns(...Uninflected::getSingular()),
-            (new Substitutions(...Inflectible::getIrregular()))->getFlippedSubstitutions(),
+            new Substitutions(...Inflectible::getIrregular())->getFlippedSubstitutions(),
         );
     }
 

--- a/src/Rules/Patterns.php
+++ b/src/Rules/Patterns.php
@@ -14,9 +14,7 @@ final readonly class Patterns
 
     public function __construct(Pattern ...$patterns)
     {
-        $patterns = array_map(static function (Pattern $pattern): string {
-            return $pattern->getPattern();
-        }, $patterns);
+        $patterns = array_map(static fn (Pattern $pattern): string => $pattern->getPattern(), $patterns);
 
         $this->regex = '/^(?:' . implode('|', $patterns) . ')$/i';
     }

--- a/src/Rules/Portuguese/Rules.php
+++ b/src/Rules/Portuguese/Rules.php
@@ -16,7 +16,7 @@ final class Rules
         return new Ruleset(
             new Transformations(...Inflectible::getSingular()),
             new Patterns(...Uninflected::getSingular()),
-            (new Substitutions(...Inflectible::getIrregular()))->getFlippedSubstitutions(),
+            new Substitutions(...Inflectible::getIrregular())->getFlippedSubstitutions(),
         );
     }
 

--- a/src/Rules/Spanish/Rules.php
+++ b/src/Rules/Spanish/Rules.php
@@ -16,7 +16,7 @@ final class Rules
         return new Ruleset(
             new Transformations(...Inflectible::getSingular()),
             new Patterns(...Uninflected::getSingular()),
-            (new Substitutions(...Inflectible::getIrregular()))->getFlippedSubstitutions(),
+            new Substitutions(...Inflectible::getIrregular())->getFlippedSubstitutions(),
         );
     }
 

--- a/src/Rules/Swedish/Rules.php
+++ b/src/Rules/Swedish/Rules.php
@@ -16,7 +16,7 @@ final class Rules
         return new Ruleset(
             new Transformations(...Inflectible::getSingular()),
             new Patterns(...Uninflected::getSingular()),
-            (new Substitutions(...Inflectible::getIrregular()))->getFlippedSubstitutions(),
+            new Substitutions(...Inflectible::getIrregular())->getFlippedSubstitutions(),
         );
     }
 

--- a/src/Rules/Turkish/Rules.php
+++ b/src/Rules/Turkish/Rules.php
@@ -16,7 +16,7 @@ final class Rules
         return new Ruleset(
             new Transformations(...Inflectible::getSingular()),
             new Patterns(...Uninflected::getSingular()),
-            (new Substitutions(...Inflectible::getIrregular()))->getFlippedSubstitutions(),
+            new Substitutions(...Inflectible::getIrregular())->getFlippedSubstitutions(),
         );
     }
 


### PR DESCRIPTION
I did not commit one of the changes because it is already proposed in #334

Configuration:

```php
<?php

declare(strict_types=1);

use Rector\Config\RectorConfig;

return RectorConfig::configure()
	->withPaths([
	__DIR__ . '/src',
	__DIR__ . '/tests',
	])
	->withPhpSets();
```