### PR TITLE
Use #[Override] attribute

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,3 +8,4 @@ parameters:
     paths:
       - src
       - tests
+    checkMissingOverrideMethodAttribute: true

--- a/src/CachedWordInflector.php
+++ b/src/CachedWordInflector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\Inflector;
 
+use Override;
+
 final class CachedWordInflector implements WordInflector
 {
     /** @var string[] */
@@ -13,6 +15,7 @@ final class CachedWordInflector implements WordInflector
     {
     }
 
+    #[Override]
     public function inflect(string $word): string
     {
         return $this->cache[$word] ?? $this->cache[$word] = $this->wordInflector->inflect($word);

--- a/src/GenericLanguageInflectorFactory.php
+++ b/src/GenericLanguageInflectorFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Inflector;
 
 use Doctrine\Inflector\Rules\Ruleset;
+use Override;
 
 use function array_unshift;
 
@@ -22,6 +23,7 @@ abstract class GenericLanguageInflectorFactory implements LanguageInflectorFacto
         $this->pluralRulesets[]   = $this->getPluralRuleset();
     }
 
+    #[Override]
     final public function build(): Inflector
     {
         return new Inflector(
@@ -34,6 +36,7 @@ abstract class GenericLanguageInflectorFactory implements LanguageInflectorFacto
         );
     }
 
+    #[Override]
     final public function withSingularRules(Ruleset|null $singularRules, bool $reset = false): LanguageInflectorFactory
     {
         if ($reset) {
@@ -47,6 +50,7 @@ abstract class GenericLanguageInflectorFactory implements LanguageInflectorFacto
         return $this;
     }
 
+    #[Override]
     final public function withPluralRules(Ruleset|null $pluralRules, bool $reset = false): LanguageInflectorFactory
     {
         if ($reset) {

--- a/src/NoopWordInflector.php
+++ b/src/NoopWordInflector.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\Inflector;
 
+use Override;
+
 final class NoopWordInflector implements WordInflector
 {
+    #[Override]
     public function inflect(string $word): string
     {
         return $word;

--- a/src/Rules/English/InflectorFactory.php
+++ b/src/Rules/English/InflectorFactory.php
@@ -6,14 +6,17 @@ namespace Doctrine\Inflector\Rules\English;
 
 use Doctrine\Inflector\GenericLanguageInflectorFactory;
 use Doctrine\Inflector\Rules\Ruleset;
+use Override;
 
 final class InflectorFactory extends GenericLanguageInflectorFactory
 {
+    #[Override]
     protected function getSingularRuleset(): Ruleset
     {
         return Rules::getSingularRuleset();
     }
 
+    #[Override]
     protected function getPluralRuleset(): Ruleset
     {
         return Rules::getPluralRuleset();

--- a/src/Rules/Esperanto/InflectorFactory.php
+++ b/src/Rules/Esperanto/InflectorFactory.php
@@ -6,14 +6,17 @@ namespace Doctrine\Inflector\Rules\Esperanto;
 
 use Doctrine\Inflector\GenericLanguageInflectorFactory;
 use Doctrine\Inflector\Rules\Ruleset;
+use Override;
 
 final class InflectorFactory extends GenericLanguageInflectorFactory
 {
+    #[Override]
     protected function getSingularRuleset(): Ruleset
     {
         return Rules::getSingularRuleset();
     }
 
+    #[Override]
     protected function getPluralRuleset(): Ruleset
     {
         return Rules::getPluralRuleset();

--- a/src/Rules/French/InflectorFactory.php
+++ b/src/Rules/French/InflectorFactory.php
@@ -6,14 +6,17 @@ namespace Doctrine\Inflector\Rules\French;
 
 use Doctrine\Inflector\GenericLanguageInflectorFactory;
 use Doctrine\Inflector\Rules\Ruleset;
+use Override;
 
 final class InflectorFactory extends GenericLanguageInflectorFactory
 {
+    #[Override]
     protected function getSingularRuleset(): Ruleset
     {
         return Rules::getSingularRuleset();
     }
 
+    #[Override]
     protected function getPluralRuleset(): Ruleset
     {
         return Rules::getPluralRuleset();

--- a/src/Rules/Italian/InflectorFactory.php
+++ b/src/Rules/Italian/InflectorFactory.php
@@ -6,14 +6,17 @@ namespace Doctrine\Inflector\Rules\Italian;
 
 use Doctrine\Inflector\GenericLanguageInflectorFactory;
 use Doctrine\Inflector\Rules\Ruleset;
+use Override;
 
 final class InflectorFactory extends GenericLanguageInflectorFactory
 {
+    #[Override]
     protected function getSingularRuleset(): Ruleset
     {
         return Rules::getSingularRuleset();
     }
 
+    #[Override]
     protected function getPluralRuleset(): Ruleset
     {
         return Rules::getPluralRuleset();

--- a/src/Rules/NorwegianBokmal/InflectorFactory.php
+++ b/src/Rules/NorwegianBokmal/InflectorFactory.php
@@ -6,14 +6,17 @@ namespace Doctrine\Inflector\Rules\NorwegianBokmal;
 
 use Doctrine\Inflector\GenericLanguageInflectorFactory;
 use Doctrine\Inflector\Rules\Ruleset;
+use Override;
 
 final class InflectorFactory extends GenericLanguageInflectorFactory
 {
+    #[Override]
     protected function getSingularRuleset(): Ruleset
     {
         return Rules::getSingularRuleset();
     }
 
+    #[Override]
     protected function getPluralRuleset(): Ruleset
     {
         return Rules::getPluralRuleset();

--- a/src/Rules/Portuguese/InflectorFactory.php
+++ b/src/Rules/Portuguese/InflectorFactory.php
@@ -6,14 +6,17 @@ namespace Doctrine\Inflector\Rules\Portuguese;
 
 use Doctrine\Inflector\GenericLanguageInflectorFactory;
 use Doctrine\Inflector\Rules\Ruleset;
+use Override;
 
 final class InflectorFactory extends GenericLanguageInflectorFactory
 {
+    #[Override]
     protected function getSingularRuleset(): Ruleset
     {
         return Rules::getSingularRuleset();
     }
 
+    #[Override]
     protected function getPluralRuleset(): Ruleset
     {
         return Rules::getPluralRuleset();

--- a/src/Rules/Spanish/InflectorFactory.php
+++ b/src/Rules/Spanish/InflectorFactory.php
@@ -6,14 +6,17 @@ namespace Doctrine\Inflector\Rules\Spanish;
 
 use Doctrine\Inflector\GenericLanguageInflectorFactory;
 use Doctrine\Inflector\Rules\Ruleset;
+use Override;
 
 final class InflectorFactory extends GenericLanguageInflectorFactory
 {
+    #[Override]
     protected function getSingularRuleset(): Ruleset
     {
         return Rules::getSingularRuleset();
     }
 
+    #[Override]
     protected function getPluralRuleset(): Ruleset
     {
         return Rules::getPluralRuleset();

--- a/src/Rules/Substitutions.php
+++ b/src/Rules/Substitutions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Inflector\Rules;
 
 use Doctrine\Inflector\WordInflector;
+use Override;
 
 use function strtolower;
 use function strtoupper;
@@ -36,6 +37,7 @@ final class Substitutions implements WordInflector
         return new Substitutions(...$substitutions);
     }
 
+    #[Override]
     public function inflect(string $word): string
     {
         $lowerWord = strtolower($word);

--- a/src/Rules/Swedish/InflectorFactory.php
+++ b/src/Rules/Swedish/InflectorFactory.php
@@ -6,14 +6,17 @@ namespace Doctrine\Inflector\Rules\Swedish;
 
 use Doctrine\Inflector\GenericLanguageInflectorFactory;
 use Doctrine\Inflector\Rules\Ruleset;
+use Override;
 
 final class InflectorFactory extends GenericLanguageInflectorFactory
 {
+    #[Override]
     protected function getSingularRuleset(): Ruleset
     {
         return Rules::getSingularRuleset();
     }
 
+    #[Override]
     protected function getPluralRuleset(): Ruleset
     {
         return Rules::getPluralRuleset();

--- a/src/Rules/Transformation.php
+++ b/src/Rules/Transformation.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Inflector\Rules;
 
 use Doctrine\Inflector\WordInflector;
+use Override;
 
 use function preg_replace;
 
@@ -24,6 +25,7 @@ final class Transformation implements WordInflector
         return $this->replacement;
     }
 
+    #[Override]
     public function inflect(string $word): string
     {
         return (string) preg_replace($this->pattern->getRegex(), $this->replacement, $word);

--- a/src/Rules/Transformations.php
+++ b/src/Rules/Transformations.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Inflector\Rules;
 
 use Doctrine\Inflector\WordInflector;
+use Override;
 
 final readonly class Transformations implements WordInflector
 {
@@ -16,6 +17,7 @@ final readonly class Transformations implements WordInflector
         $this->transformations = $transformations;
     }
 
+    #[Override]
     public function inflect(string $word): string
     {
         foreach ($this->transformations as $transformation) {

--- a/src/Rules/Turkish/InflectorFactory.php
+++ b/src/Rules/Turkish/InflectorFactory.php
@@ -6,14 +6,17 @@ namespace Doctrine\Inflector\Rules\Turkish;
 
 use Doctrine\Inflector\GenericLanguageInflectorFactory;
 use Doctrine\Inflector\Rules\Ruleset;
+use Override;
 
 final class InflectorFactory extends GenericLanguageInflectorFactory
 {
+    #[Override]
     protected function getSingularRuleset(): Ruleset
     {
         return Rules::getSingularRuleset();
     }
 
+    #[Override]
     protected function getPluralRuleset(): Ruleset
     {
         return Rules::getPluralRuleset();

--- a/src/RulesetInflector.php
+++ b/src/RulesetInflector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Inflector;
 
 use Doctrine\Inflector\Rules\Ruleset;
+use Override;
 
 use function array_merge;
 
@@ -27,6 +28,7 @@ final readonly class RulesetInflector implements WordInflector
         $this->rulesets = array_merge([$ruleset], $rulesets);
     }
 
+    #[Override]
     public function inflect(string $word): string
     {
         if ($word === '') {

--- a/tests/CachedWordInflectorTest.php
+++ b/tests/CachedWordInflectorTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Inflector;
 
 use Doctrine\Inflector\CachedWordInflector;
 use Doctrine\Inflector\WordInflector;
+use Override;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -26,6 +27,7 @@ class CachedWordInflectorTest extends TestCase
         self::assertSame('out', $this->cachedWordInflector->inflect('in'));
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->wordInflector = $this->createMock(WordInflector::class);

--- a/tests/InflectorTest.php
+++ b/tests/InflectorTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Inflector;
 
 use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\WordInflector;
+use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -133,6 +134,7 @@ class InflectorTest extends TestCase
         self::assertSame('out', $this->inflector->singularize('in'));
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->singularInflector = $this->createMock(WordInflector::class);

--- a/tests/NoopWordInflectorTest.php
+++ b/tests/NoopWordInflectorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Inflector;
 
 use Doctrine\Inflector\NoopWordInflector;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class NoopWordInflectorTest extends TestCase
@@ -17,6 +18,7 @@ class NoopWordInflectorTest extends TestCase
         self::assertSame('bar', $this->inflector->inflect('bar'));
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->inflector = new NoopWordInflector();

--- a/tests/Rules/English/EnglishFunctionalTest.php
+++ b/tests/Rules/English/EnglishFunctionalTest.php
@@ -8,6 +8,7 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Inflector\Language;
 use Doctrine\Tests\Inflector\Rules\LanguageFunctionalTestCase;
+use Override;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 use function sprintf;
@@ -15,6 +16,7 @@ use function sprintf;
 class EnglishFunctionalTest extends LanguageFunctionalTestCase
 {
     /** @return string[][] */
+    #[Override]
     public static function dataSampleWords(): array
     {
         return [
@@ -445,6 +447,7 @@ class EnglishFunctionalTest extends LanguageFunctionalTestCase
         );
     }
 
+    #[Override]
     protected function createInflector(): Inflector
     {
         return InflectorFactory::createForLanguage(Language::ENGLISH)->build();

--- a/tests/Rules/Esperanto/EsperantoFunctionalTest.php
+++ b/tests/Rules/Esperanto/EsperantoFunctionalTest.php
@@ -8,10 +8,12 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Inflector\Language;
 use Doctrine\Tests\Inflector\Rules\LanguageFunctionalTestCase;
+use Override;
 
 class EsperantoFunctionalTest extends LanguageFunctionalTestCase
 {
     /** @return string[][] */
+    #[Override]
     public static function dataSampleWords(): array
     {
         return [
@@ -28,6 +30,7 @@ class EsperantoFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    #[Override]
     protected function createInflector(): Inflector
     {
         return InflectorFactory::createForLanguage(Language::ESPERANTO)->build();

--- a/tests/Rules/French/FrenchFunctionalTest.php
+++ b/tests/Rules/French/FrenchFunctionalTest.php
@@ -8,10 +8,12 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Inflector\Language;
 use Doctrine\Tests\Inflector\Rules\LanguageFunctionalTestCase;
+use Override;
 
 class FrenchFunctionalTest extends LanguageFunctionalTestCase
 {
     /** @return string[][] */
+    #[Override]
     public static function dataSampleWords(): array
     {
         return [
@@ -61,6 +63,7 @@ class FrenchFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    #[Override]
     protected function createInflector(): Inflector
     {
         return InflectorFactory::createForLanguage(Language::FRENCH)->build();

--- a/tests/Rules/Italian/ItalianFunctionalTest.php
+++ b/tests/Rules/Italian/ItalianFunctionalTest.php
@@ -8,10 +8,12 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Inflector\Language;
 use Doctrine\Tests\Inflector\Rules\LanguageFunctionalTestCase;
+use Override;
 
 class ItalianFunctionalTest extends LanguageFunctionalTestCase
 {
     /** @return string[][] */
+    #[Override]
     public static function dataSampleWords(): array
     {
         return [
@@ -125,6 +127,7 @@ class ItalianFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    #[Override]
     protected function createInflector(): Inflector
     {
         return InflectorFactory::createForLanguage(Language::ITALIAN)->build();

--- a/tests/Rules/NorwegianBokmal/NorwegianBokmalFunctionalTest.php
+++ b/tests/Rules/NorwegianBokmal/NorwegianBokmalFunctionalTest.php
@@ -8,10 +8,12 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Inflector\Language;
 use Doctrine\Tests\Inflector\Rules\LanguageFunctionalTestCase;
+use Override;
 
 class NorwegianBokmalFunctionalTest extends LanguageFunctionalTestCase
 {
     /** @return string[][] */
+    #[Override]
     public static function dataSampleWords(): array
     {
         return [
@@ -29,6 +31,7 @@ class NorwegianBokmalFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    #[Override]
     protected function createInflector(): Inflector
     {
         return InflectorFactory::createForLanguage(Language::NORWEGIAN_BOKMAL)->build();

--- a/tests/Rules/PatternTest.php
+++ b/tests/Rules/PatternTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Inflector\Rules;
 
 use Doctrine\Inflector\Rules\Pattern;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class PatternTest extends TestCase
@@ -33,6 +34,7 @@ class PatternTest extends TestCase
         self::assertTrue($this->pattern->matches('test'));
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->pattern = new Pattern('test');

--- a/tests/Rules/PatternsTest.php
+++ b/tests/Rules/PatternsTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Inflector\Rules;
 
 use Doctrine\Inflector\Rules\Pattern;
 use Doctrine\Inflector\Rules\Patterns;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class PatternsTest extends TestCase
@@ -18,6 +19,7 @@ class PatternsTest extends TestCase
         self::assertFalse($this->patterns->matches('test2'));
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->patterns = new Patterns(new Pattern('test1'));

--- a/tests/Rules/Portuguese/PortugueseFunctionalTest.php
+++ b/tests/Rules/Portuguese/PortugueseFunctionalTest.php
@@ -8,10 +8,12 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Inflector\Language;
 use Doctrine\Tests\Inflector\Rules\LanguageFunctionalTestCase;
+use Override;
 
 class PortugueseFunctionalTest extends LanguageFunctionalTestCase
 {
     /** @return string[][] */
+    #[Override]
     public static function dataSampleWords(): array
     {
         return [
@@ -47,6 +49,7 @@ class PortugueseFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    #[Override]
     protected function createInflector(): Inflector
     {
         return InflectorFactory::createForLanguage(Language::PORTUGUESE)->build();

--- a/tests/Rules/RulesetTest.php
+++ b/tests/Rules/RulesetTest.php
@@ -12,6 +12,7 @@ use Doctrine\Inflector\Rules\Substitutions;
 use Doctrine\Inflector\Rules\Transformation;
 use Doctrine\Inflector\Rules\Transformations;
 use Doctrine\Inflector\Rules\Word;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class RulesetTest extends TestCase
@@ -39,6 +40,7 @@ class RulesetTest extends TestCase
         self::assertSame($this->irregular, $this->ruleset->getIrregular());
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->regular     = new Transformations(

--- a/tests/Rules/Spanish/SpanishFunctionalTest.php
+++ b/tests/Rules/Spanish/SpanishFunctionalTest.php
@@ -8,10 +8,12 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Inflector\Language;
 use Doctrine\Tests\Inflector\Rules\LanguageFunctionalTestCase;
+use Override;
 
 class SpanishFunctionalTest extends LanguageFunctionalTestCase
 {
     /** @return string[][] */
+    #[Override]
     public static function dataSampleWords(): array
     {
         return [
@@ -54,6 +56,7 @@ class SpanishFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    #[Override]
     protected function createInflector(): Inflector
     {
         return InflectorFactory::createForLanguage(Language::SPANISH)->build();

--- a/tests/Rules/SubstitutionTest.php
+++ b/tests/Rules/SubstitutionTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Inflector\Rules;
 
 use Doctrine\Inflector\Rules\Substitution;
 use Doctrine\Inflector\Rules\Word;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class SubstitutionTest extends TestCase
@@ -22,6 +23,7 @@ class SubstitutionTest extends TestCase
         self::assertSame('to', $this->substitution->getTo()->getWord());
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->substitution = new Substitution(new Word('from'), new Word('to'));

--- a/tests/Rules/SubstitutionsTest.php
+++ b/tests/Rules/SubstitutionsTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\Inflector\Rules;
 use Doctrine\Inflector\Rules\Substitution;
 use Doctrine\Inflector\Rules\Substitutions;
 use Doctrine\Inflector\Rules\Word;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class SubstitutionsTest extends TestCase
@@ -28,6 +29,7 @@ class SubstitutionsTest extends TestCase
         self::assertSame('spinor', $this->irregular->inflect('spins'));
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->substitutions = [

--- a/tests/Rules/Swedish/SwedishFunctionalTest.php
+++ b/tests/Rules/Swedish/SwedishFunctionalTest.php
@@ -8,10 +8,12 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Inflector\Language;
 use Doctrine\Tests\Inflector\Rules\LanguageFunctionalTestCase;
+use Override;
 
 class SwedishFunctionalTest extends LanguageFunctionalTestCase
 {
     /** @return string[][] */
+    #[Override]
     public static function dataSampleWords(): array
     {
         return [
@@ -85,6 +87,7 @@ class SwedishFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    #[Override]
     protected function createInflector(): Inflector
     {
         return InflectorFactory::createForLanguage(Language::SWEDISH)->build();

--- a/tests/Rules/TransformationTest.php
+++ b/tests/Rules/TransformationTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Inflector\Rules;
 
 use Doctrine\Inflector\Rules\Pattern;
 use Doctrine\Inflector\Rules\Transformation;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class TransformationTest extends TestCase
@@ -27,6 +28,7 @@ class TransformationTest extends TestCase
         self::assertSame('test', $this->transformation->inflect('tests'));
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->transformation = new Transformation(new Pattern('s$'), '');

--- a/tests/Rules/TransformationsTest.php
+++ b/tests/Rules/TransformationsTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\Inflector\Rules;
 use Doctrine\Inflector\Rules\Pattern;
 use Doctrine\Inflector\Rules\Transformation;
 use Doctrine\Inflector\Rules\Transformations;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class TransformationsTest extends TestCase
@@ -18,6 +19,7 @@ class TransformationsTest extends TestCase
         self::assertSame('customizables', $this->transformations->inflect('custom'));
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->transformations = new Transformations(new Transformation(new Pattern('/^(custom)$/i'), '\1izables'));

--- a/tests/Rules/Turkish/TurkishFunctionalTest.php
+++ b/tests/Rules/Turkish/TurkishFunctionalTest.php
@@ -8,10 +8,12 @@ use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
 use Doctrine\Inflector\Language;
 use Doctrine\Tests\Inflector\Rules\LanguageFunctionalTestCase;
+use Override;
 
 class TurkishFunctionalTest extends LanguageFunctionalTestCase
 {
     /** @return string[][] */
+    #[Override]
     public static function dataSampleWords(): array
     {
         return [
@@ -27,6 +29,7 @@ class TurkishFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    #[Override]
     protected function createInflector(): Inflector
     {
         return InflectorFactory::createForLanguage(Language::TURKISH)->build();

--- a/tests/Rules/WordTest.php
+++ b/tests/Rules/WordTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\Inflector\Rules;
 
 use Doctrine\Inflector\Rules\Word;
+use Override;
 use PHPUnit\Framework\TestCase;
 
 class WordTest extends TestCase
@@ -16,6 +17,7 @@ class WordTest extends TestCase
         self::assertSame('test', $this->word->getWord());
     }
 
+    #[Override]
     protected function setUp(): void
     {
         $this->word = new Word('test');


### PR DESCRIPTION
Configuration:

```php
<?php

declare(strict_types=1);

use Rector\Config\RectorConfig;
use Rector\Php83\Rector\ClassMethod\AddOverrideAttributeToOverriddenMethodsRector;

return RectorConfig::configure()
	->withPaths([
	__DIR__ . '/src',
	__DIR__ . '/tests',
	])
	->withConfiguredRule(AddOverrideAttributeToOverriddenMethodsRector::class, [
	'allow_override_empty_method' => true,
	]);
```