### PR TITLE
Introduce Persian language

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -43,6 +43,7 @@ The supported languages are as follows:
 - ``Language::FRENCH``
 - ``Language::ITALIAN``
 - ``Language::NORWEGIAN_BOKMAL``
+- ``Language::PERSIAN``
 - ``Language::PORTUGUESE``
 - ``Language::SPANISH``
 - ``Language::TURKISH``

--- a/src/InflectorFactory.php
+++ b/src/InflectorFactory.php
@@ -9,6 +9,7 @@ use Doctrine\Inflector\Rules\Esperanto;
 use Doctrine\Inflector\Rules\French;
 use Doctrine\Inflector\Rules\Italian;
 use Doctrine\Inflector\Rules\NorwegianBokmal;
+use Doctrine\Inflector\Rules\Persian;
 use Doctrine\Inflector\Rules\Portuguese;
 use Doctrine\Inflector\Rules\Spanish;
 use Doctrine\Inflector\Rules\Turkish;
@@ -40,6 +41,9 @@ final class InflectorFactory
 
             case Language::NORWEGIAN_BOKMAL:
                 return new NorwegianBokmal\InflectorFactory();
+
+            case Language::PERSIAN:
+                return new Persian\InflectorFactory();
 
             case Language::PORTUGUESE:
                 return new Portuguese\InflectorFactory();

--- a/src/Language.php
+++ b/src/Language.php
@@ -11,6 +11,7 @@ final class Language
     public const FRENCH           = 'french';
     public const ITALIAN          = 'italian';
     public const NORWEGIAN_BOKMAL = 'norwegian-bokmal';
+    public const PERSIAN          = 'persian';
     public const PORTUGUESE       = 'portuguese';
     public const SPANISH          = 'spanish';
     public const TURKISH          = 'turkish';

--- a/src/Rules/Persian/Inflectible.php
+++ b/src/Rules/Persian/Inflectible.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Inflector\Rules\Persian;
+
+use Doctrine\Inflector\Rules\Pattern;
+use Doctrine\Inflector\Rules\Substitution;
+use Doctrine\Inflector\Rules\Transformation;
+use Doctrine\Inflector\Rules\Word;
+
+class Inflectible
+{
+    /**
+     * @see https://en.wikipedia.org/wiki/Zero-width_non-joiner
+     * @see https://unicode-table.com/en/200C/
+     */
+    public const ZWNJ = "\u{200C}";
+
+    public const SPACE = ' ';
+
+    /** @return Transformation[] */
+    public static function getSingular(): iterable
+    {
+        yield from self::getMixedPluralToSingular();
+
+        yield new Transformation(new Pattern('(ه)ان$'), '\1');
+
+        /**
+         * It is recommended to use ZWNJ (aka: نیم‌فاصله) instead of space for Persian when concatenating words.
+         */
+        yield new Transformation(new Pattern(self::ZWNJ . 'ها$'), '');
+
+        /**
+         * But we support space, because some people use it.
+         */
+        yield new Transformation(new Pattern(self::SPACE . 'ها$'), '');
+    }
+
+    /**
+     * There are some plural words that are irregular in Persian.
+     * The source of these words is came from Arabic which is known as mixed plural (جمع مکسر)
+     * It is recommended to use Persian rules for these words instead of Arabic rules.
+     * So we support to convert them to singular from mixed plural.
+     * But when converting to plural, we use the Persian plural rules.
+     * So, when you convert these kind of words from singular to plural, you will NOT get the mixed plurals.
+     *
+     * @return Transformation[]
+     */
+    public static function getMixedPluralToSingular(): iterable
+    {
+        yield new Transformation(new Pattern('^اماکن$'), 'مکان');
+    }
+
+    /** @return Transformation[] */
+    public static function getPlural(): iterable
+    {
+        /**
+         * If a word ends with "ه", we add "ان" to the end of the word.
+         * Because adding "ها" to the end of the word will make it difficult to read.
+         * Also it will repeat the "ه" sound, like: "گیاه‌ها"
+         */
+        yield new Transformation(new Pattern('(ه)$'), '\1ان');
+
+        /**
+         * Generally, we add "ها" to the end of the word to make it plural.
+         */
+        yield new Transformation(new Pattern('$'), self::ZWNJ . 'ها');
+    }
+
+    /** @return Substitution[] */
+    public static function getIrregular(): iterable
+    {
+        yield new Substitution(new Word(''), new Word(''));
+    }
+}

--- a/src/Rules/Persian/Inflectible.php
+++ b/src/Rules/Persian/Inflectible.php
@@ -23,54 +23,185 @@ class Inflectible
     public static function getSingular(): iterable
     {
         yield from self::getMixedPluralToSingular();
-
-        yield new Transformation(new Pattern('(ه)ان$'), '\1');
-
-        /**
-         * It is recommended to use ZWNJ (aka: نیم‌فاصله) instead of space for Persian when concatenating words.
-         */
-        yield new Transformation(new Pattern(self::ZWNJ . 'ها$'), '');
+        yield from self::getLiteraryPluralToSingular();
 
         /**
-         * But we support space, because some people use it.
+         * Prefer ZWNJ (نیم‌فاصله) before ها in Persian orthography.
+         * Also accept a regular space. Bare ها is not stripped: words such as
+         * تنها and رها end with those letters but are not plurals.
          */
-        yield new Transformation(new Pattern(self::SPACE . 'ها$'), '');
+        yield new Transformation(new Pattern('/' . self::ZWNJ . 'ها$/u'), '');
+        yield new Transformation(new Pattern('/' . self::SPACE . 'ها$/u'), '');
     }
 
     /**
-     * There are some plural words that are irregular in Persian.
-     * The source of these words is came from Arabic which is known as mixed plural (جمع مکسر)
-     * It is recommended to use Persian rules for these words instead of Arabic rules.
-     * So we support to convert them to singular from mixed plural.
-     * But when converting to plural, we use the Persian plural rules.
-     * So, when you convert these kind of words from singular to plural, you will NOT get the mixed plurals.
+     * Arabic broken plurals (جمع مکسر) borrowed into Persian.
+     *
+     * Recognized only when singularizing. Pluralizing always prefers
+     * Persian suffixes (ها / ان) rather than regenerating the Arabic form.
      *
      * @return Transformation[]
      */
     public static function getMixedPluralToSingular(): iterable
     {
-        yield new Transformation(new Pattern('^اماکن$'), 'مکان');
+        // Exact pairs: a blanket suffix rule would corrupt stems such as مکان / زمان.
+        $pairs = [
+            'اماکن' => 'مکان',
+            'کتب' => 'کتاب',
+            'علوم' => 'علم',
+            'اخبار' => 'خبر',
+            'اولاد' => 'ولد',
+            'اساتید' => 'استاد',
+            'امور' => 'امر',
+            'افراد' => 'فرد',
+            'اطفال' => 'طفل',
+            'حروف' => 'حرف',
+            'مدارس' => 'مدرسه',
+            'مساجد' => 'مسجد',
+            'مکاتب' => 'مکتب',
+            'جبال' => 'جبل',
+            'قلوب' => 'قلب',
+            'دروس' => 'درس',
+            'ظروف' => 'ظرف',
+            'آثار' => 'اثر',
+            'اعداد' => 'عدد',
+            'اشیا' => 'شیء',
+            'اشخاص' => 'شخص',
+            'ادیان' => 'دین',
+            'ابیات' => 'بیت',
+            'علما' => 'عالم',
+            'ادبا' => 'ادیب',
+            'غربا' => 'غریب',
+            'رجال' => 'رجل',
+            'مجالس' => 'مجلس',
+            'منازل' => 'منزل',
+            'مفاتیح' => 'مفتاح',
+            'بلدان' => 'بلد',
+            'اجسام' => 'جسم',
+            'اعضا' => 'عضو',
+            'اقوال' => 'قول',
+            'الفاظ' => 'لفظ',
+            'رسل' => 'رسول',
+            'صور' => 'صورت',
+            'علل' => 'علت',
+            'ملل' => 'ملت',
+            'شعرا' => 'شاعر',
+            'فقرا' => 'فقیر',
+            'فضلا' => 'فاضل',
+            'افکار' => 'فکر',
+            'اعمال' => 'عمل',
+            'اخلاق' => 'خلق',
+            'مراحل' => 'مرحله',
+            'مذاهب' => 'مذهب',
+            'ائمه' => 'امام',
+            'ادعیه' => 'دعا',
+            'امراض' => 'مرض',
+            'حقوق' => 'حق',
+            'حقایق' => 'حقیقت',
+            'مراکز' => 'مرکز',
+            'میادین' => 'میدان',
+            'فرامین' => 'فرمان',
+            'بنادر' => 'بندر',
+            'حیوانات' => 'حیوان',
+            'محصولات' => 'محصول',
+            'امکانات' => 'امکان',
+            'تشکیلات' => 'تشکیل',
+            'اطلاعات' => 'اطلاع',
+            'تجربیات' => 'تجربه',
+        ];
+
+        foreach ($pairs as $plural => $singular) {
+            yield new Transformation(new Pattern('/^' . $plural . '$/u'), $singular);
+        }
+    }
+
+    /**
+     * Literary Persian plurals (گان / ان on inanimates) that should singularize,
+     * even when pluralize prefers the everyday ها form.
+     *
+     * Exact matches only: a bare گان$ rule would corrupt place names such as گرگان.
+     *
+     * @return Transformation[]
+     */
+    public static function getLiteraryPluralToSingular(): iterable
+    {
+        $pairs = [
+            'ستارگان' => 'ستاره',
+            'بچگان' => 'بچه',
+            'بندگان' => 'بنده',
+            'فرشتگان' => 'فرشته',
+            'همسایگان' => 'همسایه',
+            'رفتگان' => 'رفته',
+            'زندگان' => 'زنده',
+            'چشمان' => 'چشم',
+            'سخنان' => 'سخن',
+            'دستان' => 'دست',
+        ];
+
+        foreach ($pairs as $plural => $singular) {
+            yield new Transformation(new Pattern('/^' . $plural . '$/u'), $singular);
+        }
     }
 
     /** @return Transformation[] */
     public static function getPlural(): iterable
     {
-        /**
-         * If a word ends with "ه", we add "ان" to the end of the word.
-         * Because adding "ها" to the end of the word will make it difficult to read.
-         * Also it will repeat the "ه" sound, like: "گیاه‌ها"
-         */
-        yield new Transformation(new Pattern('(ه)$'), '\1ان');
-
-        /**
-         * Generally, we add "ها" to the end of the word to make it plural.
-         */
-        yield new Transformation(new Pattern('$'), self::ZWNJ . 'ها');
+        // Universal productive plural: noun + ZWNJ + ها
+        yield new Transformation(new Pattern('/$/u'), self::ZWNJ . 'ها');
     }
 
-    /** @return Substitution[] */
+    /**
+     * Formal / literary animate plurals with ان / گان / یان.
+     * These cannot be inferred from spelling alone (خانه vs پادشاه both end in ه),
+     * so they are listed explicitly. Default pluralization uses ها.
+     *
+     * @return Substitution[]
+     */
     public static function getIrregular(): iterable
     {
-        yield new Substitution(new Word(''), new Word(''));
+        $pairs = [
+            // اه + ان (pronounced ه)
+            'پادشاه' => 'پادشاهان',
+            'گیاه' => 'گیاهان',
+            'گواه' => 'گواهان',
+            'گناه' => 'گناهان',
+            'شاه' => 'شاهان',
+            // consonant + ان
+            'مرد' => 'مردان',
+            'زن' => 'زنان',
+            'دوست' => 'دوستان',
+            'استاد' => 'استادان',
+            'کودک' => 'کودکان',
+            'بزرگ' => 'بزرگان',
+            'دختر' => 'دختران',
+            'پسر' => 'پسران',
+            'برادر' => 'برادران',
+            'خواهر' => 'خواهران',
+            'معلم' => 'معلمان',
+            'کارمند' => 'کارمندان',
+            'سرباز' => 'سربازان',
+            'هنرمند' => 'هنرمندان',
+            'دانشمند' => 'دانشمندان',
+            'وزیر' => 'وزیران',
+            'جانور' => 'جانوران',
+            'عزیز' => 'عزیزان',
+            // silent ه → گان
+            'نویسنده' => 'نویسندگان',
+            'پرنده' => 'پرندگان',
+            'همسایه' => 'همسایگان',
+            'بنده' => 'بندگان',
+            'فرشته' => 'فرشتگان',
+            // vowel + یان
+            'دانشجو' => 'دانشجویان',
+            'آقا' => 'آقایان',
+            'دانا' => 'دانایان',
+            'سخنگو' => 'سخنگویان',
+            'آشنا' => 'آشنایان',
+            'ایرانی' => 'ایرانیان',
+        ];
+
+        foreach ($pairs as $singular => $plural) {
+            yield new Substitution(new Word($singular), new Word($plural));
+        }
     }
 }

--- a/src/Rules/Persian/InflectorFactory.php
+++ b/src/Rules/Persian/InflectorFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Inflector\Rules\Persian;
+
+use Doctrine\Inflector\GenericLanguageInflectorFactory;
+use Doctrine\Inflector\Rules\Ruleset;
+
+final class InflectorFactory extends GenericLanguageInflectorFactory
+{
+    protected function getSingularRuleset(): Ruleset
+    {
+        return Rules::getSingularRuleset();
+    }
+
+    protected function getPluralRuleset(): Ruleset
+    {
+        return Rules::getPluralRuleset();
+    }
+}

--- a/src/Rules/Persian/Rules.php
+++ b/src/Rules/Persian/Rules.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Inflector\Rules\Persian;
+
+use Doctrine\Inflector\Rules\Patterns;
+use Doctrine\Inflector\Rules\Ruleset;
+use Doctrine\Inflector\Rules\Substitutions;
+use Doctrine\Inflector\Rules\Transformations;
+
+final class Rules
+{
+    public static function getSingularRuleset(): Ruleset
+    {
+        return new Ruleset(
+            new Transformations(...Inflectible::getSingular()),
+            new Patterns(...Uninflected::getSingular()),
+            (new Substitutions(...Inflectible::getIrregular()))->getFlippedSubstitutions()
+        );
+    }
+
+    public static function getPluralRuleset(): Ruleset
+    {
+        return new Ruleset(
+            new Transformations(...Inflectible::getPlural()),
+            new Patterns(...Uninflected::getPlural()),
+            new Substitutions(...Inflectible::getIrregular())
+        );
+    }
+}

--- a/src/Rules/Persian/Uninflected.php
+++ b/src/Rules/Persian/Uninflected.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Inflector\Rules\Persian;
+
+use Doctrine\Inflector\Rules\Pattern;
+
+final class Uninflected
+{
+    /** @return Pattern[] */
+    public static function getSingular(): iterable
+    {
+        yield from self::getDefault();
+    }
+
+    /** @return Pattern[] */
+    public static function getPlural(): iterable
+    {
+        yield from self::getDefault();
+    }
+
+    /** @return Pattern[] */
+    private static function getDefault(): iterable
+    {
+        // Collective / invariant nouns that are not pluralized with ها
+        yield new Pattern('مردم');
+    }
+}

--- a/tests/InflectorFactoryTest.php
+++ b/tests/InflectorFactoryTest.php
@@ -11,6 +11,7 @@ use Doctrine\Inflector\Rules\English\InflectorFactory as EnglishInflectorFactory
 use Doctrine\Inflector\Rules\Esperanto\InflectorFactory as EsperantoInflectorFactory;
 use Doctrine\Inflector\Rules\French\InflectorFactory as FrenchInflectorFactory;
 use Doctrine\Inflector\Rules\NorwegianBokmal\InflectorFactory as NorwegianBokmalInflectorFactory;
+use Doctrine\Inflector\Rules\Persian\InflectorFactory as PersianInflectorFactory;
 use Doctrine\Inflector\Rules\Portuguese\InflectorFactory as PortugueseInflectorFactory;
 use Doctrine\Inflector\Rules\Spanish\InflectorFactory as SpanishInflectorFactory;
 use Doctrine\Inflector\Rules\Turkish\InflectorFactory as TurkishInflectorFactory;
@@ -44,6 +45,7 @@ class InflectorFactoryTest extends TestCase
         yield 'Esperanto' => [EsperantoInflectorFactory::class, Language::ESPERANTO];
         yield 'French' => [FrenchInflectorFactory::class, Language::FRENCH];
         yield 'Norwegian Bokmal' => [NorwegianBokmalInflectorFactory::class, Language::NORWEGIAN_BOKMAL];
+        yield 'Persian' => [PersianInflectorFactory::class, Language::PERSIAN];
         yield 'Portuguese' => [PortugueseInflectorFactory::class, Language::PORTUGUESE];
         yield 'Spanish' => [SpanishInflectorFactory::class, Language::SPANISH];
         yield 'Turkish' => [TurkishInflectorFactory::class, Language::TURKISH];

--- a/tests/Rules/Persian/PersianFunctionalTest.php
+++ b/tests/Rules/Persian/PersianFunctionalTest.php
@@ -163,6 +163,7 @@ class PersianFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    /** @dataProvider dataMixedPluralShouldBeConvertedToSingular */
     #[DataProvider('dataMixedPluralShouldBeConvertedToSingular')]
     public function testMixedPluralShouldBeConvertedToSingular(string $mixedPlural, string $singular): void
     {
@@ -193,6 +194,7 @@ class PersianFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    /** @dataProvider dataSpaceSeparatedHa */
     #[DataProvider('dataSpaceSeparatedHa')]
     public function testSpaceSeparatedHaSingularizes(string $plural, string $singular): void
     {
@@ -225,6 +227,7 @@ class PersianFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    /** @dataProvider dataLiteraryPluralSingularizes */
     #[DataProvider('dataLiteraryPluralSingularizes')]
     public function testLiteraryPluralSingularizes(string $plural, string $singular): void
     {
@@ -247,6 +250,7 @@ class PersianFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    /** @dataProvider dataPluralUninflectedWhenPluralized */
     #[DataProvider('dataPluralUninflectedWhenPluralized')]
     public function testPluralsWhenPluralizedShouldBeUninflected(string $plural): void
     {
@@ -288,6 +292,7 @@ class PersianFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    /** @dataProvider dataSingularsThatMustNotBeMangled */
     #[DataProvider('dataSingularsThatMustNotBeMangled')]
     public function testSingularsThatMustNotBeMangled(string $singular): void
     {
@@ -316,6 +321,7 @@ class PersianFunctionalTest extends LanguageFunctionalTestCase
         ];
     }
 
+    /** @dataProvider dataSilentHeInanimatesUseHa */
     #[DataProvider('dataSilentHeInanimatesUseHa')]
     public function testSilentHeInanimatesUseHa(string $singular): void
     {

--- a/tests/Rules/Persian/PersianFunctionalTest.php
+++ b/tests/Rules/Persian/PersianFunctionalTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Inflector\Rules\English;
+
+use Doctrine\Inflector\Inflector;
+use Doctrine\Inflector\InflectorFactory;
+use Doctrine\Inflector\Language;
+use Doctrine\Tests\Inflector\Rules\LanguageFunctionalTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+use function sprintf;
+
+class PersianFunctionalTest extends LanguageFunctionalTestCase
+{
+    /** @return string[][] */
+    public static function dataSampleWords(): array
+    {
+        return [
+            ['', ''],
+            ['پادشاه', 'پادشاهان'],
+            ['مکان', 'مکان‌ها'],
+        ];
+    }
+
+    /**
+     * Mixed plural test data.
+     *
+     * A list of mixed plurals that should be converted to singular.
+     * Returns an array of sample words.
+     *
+     * @return string[][]
+     */
+    public static function dataMixedPluralShouldBeConvertedToSingular(): array
+    {
+        return [
+            ['اماکن', 'مکان'],
+        ];
+    }
+
+    #[DataProvider('dataMixedPluralShouldBeConvertedToSingular')]
+    public function testMixedPluralShouldBeConvertedToSingular(string $mixedPlural, string $singular): void
+    {
+        self::assertSame(
+            $singular,
+            $this->createInflector()->singularize($mixedPlural),
+            sprintf("'%s' should be singularized to '%s' because it is a mixed plural", $mixedPlural, $singular)
+        );
+        self::assertNotSame(
+            $singular,
+            $this->createInflector()->pluralize($singular),
+            sprintf("'%s' should not be pluralized to '%s' because it is a mixed plural", $singular, $mixedPlural)
+        );
+    }
+
+    /**
+     * Singulars as Plural test data.
+     *
+     * A list of singulars that should not yield the given result if passed through `singularize`.
+     * Returns an array of sample words.
+     *
+     * @return string[][]
+     */
+    public static function dataSingularsUninflectedWhenSingularized(): array
+    {
+        // In the format array('singular', 'notEquals')
+        return [
+            ['مدرک', 'مدرک‌ها'],
+        ];
+    }
+
+    /** @dataProvider dataSingularsUninflectedWhenSingularized */
+    #[DataProvider('dataSingularsUninflectedWhenSingularized')]
+    public function testSingularsWhenSingularizedShouldBeUninflected(string $singular, string $notEquals): void
+    {
+        self::assertNotSame(
+            $notEquals,
+            $this->createInflector()->singularize($singular),
+            sprintf("'%s' should not be singularized to '%s'", $singular, $notEquals)
+        );
+    }
+
+    /**
+     * Words without plural test data.
+     *
+     * List of words that don't have a plural form.
+     *
+     * @return string[][]
+     */
+    public static function dataPluralUninflectedWhenPluralized(): array
+    {
+        return [
+            ['گروه'],
+            ['گله'],
+        ];
+    }
+
+    /** @dataProvider dataPluralUninflectedWhenPluralized */
+    #[DataProvider('dataPluralUninflectedWhenPluralized')]
+    public function testPluralsWhenPluralizedShouldBeUninflected(string $plural): void
+    {
+        $pluralized = $this->createInflector()->pluralize($plural);
+
+        self::assertSame(
+            $plural,
+            $pluralized,
+            sprintf("'%s' should not be pluralized to '%s'", $plural, $pluralized)
+        );
+    }
+
+    protected function createInflector(): Inflector
+    {
+        return InflectorFactory::createForLanguage(Language::PERSIAN)->build();
+    }
+}

--- a/tests/Rules/Persian/PersianFunctionalTest.php
+++ b/tests/Rules/Persian/PersianFunctionalTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Doctrine\Tests\Inflector\Rules\English;
+namespace Doctrine\Tests\Inflector\Rules\Persian;
 
 use Doctrine\Inflector\Inflector;
 use Doctrine\Inflector\InflectorFactory;
@@ -19,16 +19,79 @@ class PersianFunctionalTest extends LanguageFunctionalTestCase
     {
         return [
             ['', ''],
-            ['پادشاه', 'پادشاهان'],
+            // Default productive plural with ZWNJ + ها (inanimate / everyday)
+            ['کتاب', 'کتاب‌ها'],
+            ['خانه', 'خانه‌ها'],
+            ['ماشین', 'ماشین‌ها'],
+            ['گل', 'گل‌ها'],
             ['مکان', 'مکان‌ها'],
+            ['مدرک', 'مدرک‌ها'],
+            ['نامه', 'نامه‌ها'],
+            ['درخت', 'درخت‌ها'],
+            ['سیب', 'سیب‌ها'],
+            ['اتاق', 'اتاق‌ها'],
+            ['میز', 'میز‌ها'],
+            ['صندلی', 'صندلی‌ها'],
+            ['شهر', 'شهر‌ها'],
+            ['روستا', 'روستا‌ها'],
+            ['گربه', 'گربه‌ها'],
+            ['سگ', 'سگ‌ها'],
+            ['اسب', 'اسب‌ها'],
+            ['موش', 'موش‌ها'],
+            ['ستاره', 'ستاره‌ها'],
+            ['بچه', 'بچه‌ها'],
+            ['چشم', 'چشم‌ها'],
+            ['دست', 'دست‌ها'],
+            ['سخن', 'سخن‌ها'],
+            ['میدان', 'میدان‌ها'],
+            ['فرمان', 'فرمان‌ها'],
+            ['بندر', 'بندر‌ها'],
+            ['حیوان', 'حیوان‌ها'],
+            // Formal animate plurals (ان)
+            ['پادشاه', 'پادشاهان'],
+            ['گیاه', 'گیاهان'],
+            ['گواه', 'گواهان'],
+            ['گناه', 'گناهان'],
+            ['شاه', 'شاهان'],
+            ['مرد', 'مردان'],
+            ['زن', 'زنان'],
+            ['دوست', 'دوستان'],
+            ['استاد', 'استادان'],
+            ['کودک', 'کودکان'],
+            ['بزرگ', 'بزرگان'],
+            ['دختر', 'دختران'],
+            ['پسر', 'پسران'],
+            ['برادر', 'برادران'],
+            ['خواهر', 'خواهران'],
+            ['معلم', 'معلمان'],
+            ['کارمند', 'کارمندان'],
+            ['سرباز', 'سربازان'],
+            ['هنرمند', 'هنرمندان'],
+            ['دانشمند', 'دانشمندان'],
+            ['وزیر', 'وزیران'],
+            ['جانور', 'جانوران'],
+            ['عزیز', 'عزیزان'],
+            // Formal animate plurals (گان after silent ه)
+            ['نویسنده', 'نویسندگان'],
+            ['پرنده', 'پرندگان'],
+            ['همسایه', 'همسایگان'],
+            ['بنده', 'بندگان'],
+            ['فرشته', 'فرشتگان'],
+            // Formal animate plurals (یان after ا / و / ی)
+            ['دانشجو', 'دانشجویان'],
+            ['آقا', 'آقایان'],
+            ['دانا', 'دانایان'],
+            ['سخنگو', 'سخنگویان'],
+            ['آشنا', 'آشنایان'],
+            ['ایرانی', 'ایرانیان'],
         ];
     }
 
     /**
      * Mixed plural test data.
      *
-     * A list of mixed plurals that should be converted to singular.
-     * Returns an array of sample words.
+     * Arabic broken plurals should singularize to the Persian singular,
+     * but pluralizing that singular must use Persian ها / ان (not the Arabic form).
      *
      * @return string[][]
      */
@@ -36,6 +99,67 @@ class PersianFunctionalTest extends LanguageFunctionalTestCase
     {
         return [
             ['اماکن', 'مکان'],
+            ['کتب', 'کتاب'],
+            ['علوم', 'علم'],
+            ['اخبار', 'خبر'],
+            ['اولاد', 'ولد'],
+            ['اساتید', 'استاد'],
+            ['امور', 'امر'],
+            ['افراد', 'فرد'],
+            ['اطفال', 'طفل'],
+            ['حروف', 'حرف'],
+            ['مدارس', 'مدرسه'],
+            ['مساجد', 'مسجد'],
+            ['مکاتب', 'مکتب'],
+            ['جبال', 'جبل'],
+            ['قلوب', 'قلب'],
+            ['دروس', 'درس'],
+            ['ظروف', 'ظرف'],
+            ['آثار', 'اثر'],
+            ['اعداد', 'عدد'],
+            ['اشیا', 'شیء'],
+            ['اشخاص', 'شخص'],
+            ['ادیان', 'دین'],
+            ['ابیات', 'بیت'],
+            ['علما', 'عالم'],
+            ['ادبا', 'ادیب'],
+            ['غربا', 'غریب'],
+            ['رجال', 'رجل'],
+            ['مجالس', 'مجلس'],
+            ['منازل', 'منزل'],
+            ['مفاتیح', 'مفتاح'],
+            ['بلدان', 'بلد'],
+            ['اجسام', 'جسم'],
+            ['اعضا', 'عضو'],
+            ['اقوال', 'قول'],
+            ['الفاظ', 'لفظ'],
+            ['رسل', 'رسول'],
+            ['صور', 'صورت'],
+            ['علل', 'علت'],
+            ['ملل', 'ملت'],
+            ['شعرا', 'شاعر'],
+            ['فقرا', 'فقیر'],
+            ['فضلا', 'فاضل'],
+            ['افکار', 'فکر'],
+            ['اعمال', 'عمل'],
+            ['اخلاق', 'خلق'],
+            ['مراحل', 'مرحله'],
+            ['مذاهب', 'مذهب'],
+            ['ائمه', 'امام'],
+            ['ادعیه', 'دعا'],
+            ['امراض', 'مرض'],
+            ['حقوق', 'حق'],
+            ['حقایق', 'حقیقت'],
+            ['مراکز', 'مرکز'],
+            ['میادین', 'میدان'],
+            ['فرامین', 'فرمان'],
+            ['بنادر', 'بندر'],
+            ['حیوانات', 'حیوان'],
+            ['محصولات', 'محصول'],
+            ['امکانات', 'امکان'],
+            ['تشکیلات', 'تشکیل'],
+            ['اطلاعات', 'اطلاع'],
+            ['تجربیات', 'تجربه'],
         ];
     }
 
@@ -48,55 +172,81 @@ class PersianFunctionalTest extends LanguageFunctionalTestCase
             sprintf("'%s' should be singularized to '%s' because it is a mixed plural", $mixedPlural, $singular)
         );
         self::assertNotSame(
-            $singular,
+            $mixedPlural,
             $this->createInflector()->pluralize($singular),
-            sprintf("'%s' should not be pluralized to '%s' because it is a mixed plural", $singular, $mixedPlural)
+            sprintf("'%s' should not be pluralized to '%s' because Persian plurals are preferred", $singular, $mixedPlural)
         );
     }
 
     /**
-     * Singulars as Plural test data.
-     *
-     * A list of singulars that should not yield the given result if passed through `singularize`.
-     * Returns an array of sample words.
+     * Plurals written with a regular space before ها should still singularize.
      *
      * @return string[][]
      */
-    public static function dataSingularsUninflectedWhenSingularized(): array
+    public static function dataSpaceSeparatedHa(): array
     {
-        // In the format array('singular', 'notEquals')
         return [
-            ['مدرک', 'مدرک‌ها'],
+            ['کتاب ها', 'کتاب'],
+            ['خانه ها', 'خانه'],
+            ['ماشین ها', 'ماشین'],
+            ['گربه ها', 'گربه'],
         ];
     }
 
-    /** @dataProvider dataSingularsUninflectedWhenSingularized */
-    #[DataProvider('dataSingularsUninflectedWhenSingularized')]
-    public function testSingularsWhenSingularizedShouldBeUninflected(string $singular, string $notEquals): void
+    #[DataProvider('dataSpaceSeparatedHa')]
+    public function testSpaceSeparatedHaSingularizes(string $plural, string $singular): void
     {
-        self::assertNotSame(
-            $notEquals,
-            $this->createInflector()->singularize($singular),
-            sprintf("'%s' should not be singularized to '%s'", $singular, $notEquals)
+        self::assertSame(
+            $singular,
+            $this->createInflector()->singularize($plural),
+            sprintf("'%s' should be singularized to '%s'", $plural, $singular)
         );
     }
 
     /**
-     * Words without plural test data.
+     * Literary plurals should singularize even when pluralize prefers ها.
      *
-     * List of words that don't have a plural form.
+     * @return string[][]
+     */
+    public static function dataLiteraryPluralSingularizes(): array
+    {
+        return [
+            ['ستارگان', 'ستاره'],
+            ['بچگان', 'بچه'],
+            ['بندگان', 'بنده'],
+            ['فرشتگان', 'فرشته'],
+            ['همسایگان', 'همسایه'],
+            ['رفتگان', 'رفته'],
+            ['زندگان', 'زنده'],
+            ['چشمان', 'چشم'],
+            ['سخنان', 'سخن'],
+            ['دستان', 'دست'],
+            ['نویسندگان', 'نویسنده'],
+        ];
+    }
+
+    #[DataProvider('dataLiteraryPluralSingularizes')]
+    public function testLiteraryPluralSingularizes(string $plural, string $singular): void
+    {
+        self::assertSame(
+            $singular,
+            $this->createInflector()->singularize($plural),
+            sprintf("'%s' should be singularized to '%s'", $plural, $singular)
+        );
+    }
+
+    /**
+     * Words without a distinct plural form.
      *
      * @return string[][]
      */
     public static function dataPluralUninflectedWhenPluralized(): array
     {
         return [
-            ['گروه'],
-            ['گله'],
+            ['مردم'],
         ];
     }
 
-    /** @dataProvider dataPluralUninflectedWhenPluralized */
     #[DataProvider('dataPluralUninflectedWhenPluralized')]
     public function testPluralsWhenPluralizedShouldBeUninflected(string $plural): void
     {
@@ -107,6 +257,76 @@ class PersianFunctionalTest extends LanguageFunctionalTestCase
             $pluralized,
             sprintf("'%s' should not be pluralized to '%s'", $plural, $pluralized)
         );
+    }
+
+    /**
+     * Singular nouns that end in ان / گان / ها must not be mangled by singularize.
+     *
+     * @return string[][]
+     */
+    public static function dataSingularsThatMustNotBeMangled(): array
+    {
+        return [
+            // end in ان but are not plurals
+            ['مکان'],
+            ['زمان'],
+            ['زبان'],
+            ['ایران'],
+            ['نان'],
+            ['جان'],
+            ['عنوان'],
+            ['امکان'],
+            ['ایمان'],
+            // place names that look like گان / ان plurals
+            ['گرگان'],
+            ['زاهدان'],
+            ['گیلان'],
+            ['تهران'],
+            // end in ها but are not plurals
+            ['تنها'],
+            ['رها'],
+        ];
+    }
+
+    #[DataProvider('dataSingularsThatMustNotBeMangled')]
+    public function testSingularsThatMustNotBeMangled(string $singular): void
+    {
+        self::assertSame(
+            $singular,
+            $this->createInflector()->singularize($singular),
+            sprintf("'%s' should remain unchanged when singularized", $singular)
+        );
+    }
+
+    /**
+     * Silent-ه inanimates must take ها, never ان / گان.
+     *
+     * @return string[][]
+     */
+    public static function dataSilentHeInanimatesUseHa(): array
+    {
+        return [
+            ['خانه'],
+            ['نامه'],
+            ['میوه'],
+            ['هفته'],
+            ['دسته'],
+            ['جامعه'],
+            ['مدرسه'],
+        ];
+    }
+
+    #[DataProvider('dataSilentHeInanimatesUseHa')]
+    public function testSilentHeInanimatesUseHa(string $singular): void
+    {
+        $plural = $this->createInflector()->pluralize($singular);
+
+        self::assertSame(
+            $singular . "\u{200C}" . 'ها',
+            $plural,
+            sprintf("'%s' should pluralize with ZWNJ + ها, not ان/گان", $singular)
+        );
+        self::assertSame($singular, $this->createInflector()->singularize($plural));
     }
 
     protected function createInflector(): Inflector


### PR DESCRIPTION
## Summary

This PR adds Persian (Farsi) language support to Doctrine Inflector.

I did my best to cover the main Persian plural rules. Persian is a complex language and in many places it is mixed with Arabic, so there are irregular forms and exceptions. I cannot include every exception in one PR. The rules should grow over time as people find more cases.

### What is included

- `Language::PERSIAN` and factory wiring
- Default plural with ZWNJ + ها (for example کتاب → کتاب‌ها)
- Formal animate plurals with ان / گان / یان as irregulars (for example مرد → مردان, نویسنده → نویسندگان, دانشجو → دانشجویان)
- Singularize for Arabic broken (mixed) plurals (جمع مکسر), while pluralize prefers Persian forms (اماکن → مکان, but مکان → مکان‌ها)
- Uninflected collective: مردم
- Docs update in `docs/en/index.rst`
- Functional tests

### Design notes

- Default plural is ها, because it works for almost every noun.
- ان / گان / یان cannot be guessed from spelling alone (خانه vs پادشاه both end with ه), so those forms are listed as irregulars.
- Broken Arabic plurals are only handled on singularize. Pluralize uses Persian suffixes on purpose.
- This change is additive only. Existing languages are untouched.

Thanks for reviewing. Happy to improve the word lists based on feedback.