### PR TITLE
Fix singularization of raves

### DIFF
--- a/src/Rules/English/Inflectible.php
+++ b/src/Rules/English/Inflectible.php
@@ -162,6 +162,7 @@ class Inflectible
         yield new Substitution(new Word('penis'), new Word('penises'));
         yield new Substitution(new Word('person'), new Word('people'));
         yield new Substitution(new Word('plateau'), new Word('plateaux'));
+        yield new Substitution(new Word('rave'), new Word('raves'));
         yield new Substitution(new Word('runner-up'), new Word('runners-up'));
         yield new Substitution(new Word('safe'), new Word('safes'));
         yield new Substitution(new Word('save'), new Word('saves'));

--- a/tests/Rules/English/EnglishFunctionalTest.php
+++ b/tests/Rules/English/EnglishFunctionalTest.php
@@ -269,6 +269,7 @@ class EnglishFunctionalTest extends LanguageFunctionalTestCase
             ['rabies', 'rabies'],
             ['radius', 'radii'],
             ['rain', 'rain'],
+            ['rave', 'raves'],
             ['reflex', 'reflexes'],
             ['regatta', 'regattas'],
             ['research', 'research'],


### PR DESCRIPTION
Fixes #228.

Adds `rave` / `raves` to the English irregular substitutions so singularization no longer applies the generic `-ves` rule and produces `rafe`. The functional word list covers both pluralization and singularization.

Validation:
- `vendor/bin/phpunit tests/Rules/English/EnglishFunctionalTest.php`
- `vendor/bin/phpunit`
- `vendor/bin/phpcs`
- `vendor/bin/phpstan analyse --no-progress --debug --memory-limit=1G`
- `composer validate --strict --no-check-lock`